### PR TITLE
PLAT-3795: Terraform module and IAM policies for deployment

### DIFF
--- a/iam-bootstrap/bootstrap-0.json
+++ b/iam-bootstrap/bootstrap-0.json
@@ -35,7 +35,7 @@
                 "s3:PutEncryptionConfiguration"
             ],
             "Resource": [
-                "arn:aws:s3:::${deploy_id}-*"
+                "arn:${partition}:s3:::${deploy_id}-*"
             ]
         },
         {
@@ -81,10 +81,10 @@
                 "iam:UpdateAssumeRolePolicy"
             ],
             "Resource": [
-                "arn:aws:iam::${account_id}:policy/${deploy_id}-*",
-                "arn:aws:iam::${account_id}:role/${deploy_id}-*",
-                "arn:aws:iam::${account_id}:instance-profile/${deploy_id}-*",
-                "arn:aws:iam::${account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+                "arn:${partition}:iam::${account_id}:policy/${deploy_id}-*",
+                "arn:${partition}:iam::${account_id}:role/${deploy_id}-*",
+                "arn:${partition}:iam::${account_id}:instance-profile/${deploy_id}-*",
+                "arn:${partition}:iam::${account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
             ]
         },
         {
@@ -150,8 +150,8 @@
                 "backup:UntagResource"
             ],
             "Resource": [
-                "arn:aws:backup:*:${account_id}:backup-vault:${deploy_id}-efs",
-                "arn:aws:backup:*:${account_id}:backup-plan:*"
+                "arn:${partition}:backup:*:${account_id}:backup-vault:${deploy_id}-efs",
+                "arn:${partition}:backup:*:${account_id}:backup-plan:*"
             ]
         }
     ]

--- a/iam-bootstrap/bootstrap-0.json
+++ b/iam-bootstrap/bootstrap-0.json
@@ -1,0 +1,158 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "S3Gated",
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket",
+                "s3:DeleteBucketPolicy",
+                "s3:GetAccelerateConfiguration",
+                "s3:GetBucketAcl",
+                "s3:GetBucketCORS",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketPublicAccessBlock",
+                "s3:GetBucketRequestPayment",
+                "s3:GetBucketTagging",
+                "s3:GetBucketVersioning",
+                "s3:GetBucketWebsite",
+                "s3:GetEncryptionConfiguration",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetReplicationConfiguration",
+                "s3:*Object",
+                "s3:PutAccountPublicAccessBlock",
+                "s3:PutBucketAcl",
+                "s3:PutBucketLogging",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketRequestPayment",
+                "s3:PutBucketTagging",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:PutEncryptionConfiguration"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${deploy_id}-*"
+            ]
+        },
+        {
+            "Sid": "S3Ungated",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListAllMyBuckets",
+                "s3:ListBucket",
+                "s3:ListBucketVersions"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "IAMGated",
+            "Effect": "Allow",
+            "Action": [
+                "iam:AddRoleToInstanceProfile",
+                "iam:AttachRolePolicy",
+                "iam:CreateInstanceProfile",
+                "iam:CreatePolicy",
+                "iam:CreatePolicyVersion",
+                "iam:CreateRole",
+                "iam:CreateServiceLinkedRole",
+                "iam:DeleteInstanceProfile",
+                "iam:DeletePolicy",
+                "iam:DeletePolicyVersion",
+                "iam:DeleteRole",
+                "iam:DeleteRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:GetInstanceProfile",
+                "iam:GetPolicy",
+                "iam:GetPolicyVersion",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListInstanceProfilesForRole",
+                "iam:ListPolicyVersions",
+                "iam:ListRolePolicies",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:Tag*",
+                "iam:Untag*",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Resource": [
+                "arn:aws:iam::${account_id}:policy/${deploy_id}-*",
+                "arn:aws:iam::${account_id}:role/${deploy_id}-*",
+                "arn:aws:iam::${account_id}:instance-profile/${deploy_id}-*",
+                "arn:aws:iam::${account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            ]
+        },
+        {
+            "Sid": "IAMUngated",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole",
+                "iam:GetRolePolicy"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "LogsUngated",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateFlowLogs",
+                "ec2:DescribeFlowLogs",
+                "logs:CreateLogGroup",
+                "logs:CreateLogDelivery",
+                "logs:DescribeLogGroups",
+                "logs:ListTagsLogGroup",
+                "logs:ListTagsForResource"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "EKSUngated",
+            "Effect": "Allow",
+            "Action": [
+                "eks:*Addon*",
+                "eks:CreateCluster",
+                "eks:CreateNodegroup",
+                "eks:DescribeCluster",
+                "eks:DescribeNodegroup",
+                "eks:DescribeUpdate",
+                "eks:ListTagsForResource",
+                "eks:TagResource",
+                "eks:UntagResource"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Route53Ungated",
+            "Effect": "Allow",
+            "Action": [
+                "route53:ListHostedZones",
+                "route53:GetHostedZone",
+                "route53:ListTagsForResource"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "BackupGated",
+            "Effect": "Allow",
+            "Action": [
+                "backup:*BackupPlan",
+                "backup:*BackupVault*",
+                "backup:CreateBackupSelection",
+                "backup:DeleteBackupSelection",
+                "backup:GetBackupSelection",
+                "backup:ListTags",
+                "backup:TagResource",
+                "backup:UntagResource"
+            ],
+            "Resource": [
+                "arn:aws:backup:*:${account_id}:backup-vault:${deploy_id}-efs",
+                "arn:aws:backup:*:${account_id}:backup-plan:*"
+            ]
+        }
+    ]
+}

--- a/iam-bootstrap/bootstrap-1.json
+++ b/iam-bootstrap/bootstrap-1.json
@@ -1,0 +1,133 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "EFSUngated",
+            "Effect": "Allow",
+            "Action": [
+                "backup-storage:MountCapsule",
+                "elasticfilesystem:Backup",
+                "elasticfilesystem:CreateAccessPoint",
+                "elasticfilesystem:CreateFileSystem",
+                "elasticfilesystem:CreateMountTarget",
+                "elasticfilesystem:DescribeAccessPoints",
+                "elasticfilesystem:DescribeFileSystemPolicy",
+                "elasticfilesystem:DescribeFileSystems",
+                "elasticfilesystem:DescribeLifecycleConfiguration",
+                "elasticfilesystem:DescribeMountTargets",
+                "elasticfilesystem:DescribeMountTargetSecurityGroups",
+                "elasticfilesystem:ListTagsForResource",
+                "elasticfilesystem:ModifyMountTargetSecurityGroups",
+                "elasticfilesystem:TagResource",
+                "elasticfilesystem:UntagResource"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "EC2BastionGated",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:ModifyInstanceAttribute",
+                "ec2:MonitorInstances",
+                "ec2:TerminateInstances"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:ResourceTag/Name": "${deploy_id}-bastion"
+                }
+            }
+        },
+        {
+            "Sid": "EC2GeneralUngated",
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:CreateAutoScalingGroup",
+                "autoscaling:CreateOrUpdateTags",
+                "autoscaling:DeleteTags",
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeScalingActivities",
+                "autoscaling:DescribeScheduledActions",
+                "autoscaling:DescribeTags",
+                "autoscaling:UpdateAutoScalingGroup",
+                "ec2:*InternetGateway*",
+                "ec2:*NatGateway*",
+                "ec2:*NetworkAcl*",
+                "ec2:*NetworkInterface*",
+                "ec2:*Route*",
+                "ec2:*Subnet*",
+                "ec2:*Vpc*",
+                "ec2:AllocateAddress",
+                "ec2:AssociateAddress",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:CreateLaunchTemplate",
+                "ec2:CreateLaunchTemplateVersion",
+                "ec2:CreateSecurityGroup",
+                "ec2:CreateTags",
+                "ec2:DeleteKeyPair",
+                "ec2:DeleteTags",
+                "ec2:Describe*",
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeImages",
+                "ec2:DescribeInstances",
+                "ec2:DescribeLaunchTemplates",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DisassociateAddress",
+                "ec2:GetLaunchTemplateData",
+                "ec2:ImportKeyPair",
+                "ec2:ModifyInstanceMetadataOptions",
+                "ec2:ReleaseAddress",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:RunInstances"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "KMSUngated",
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateGrant",
+                "kms:CreateAlias",
+                "kms:CreateKey",
+                "kms:DescribeKey",
+                "kms:EnableKeyRotation",
+                "kms:GenerateDataKey",
+                "kms:GetKeyRotationStatus",
+                "kms:GetKeyPolicy",
+                "kms:ListResourceTags",
+                "kms:PutKeyPolicy",
+                "kms:RetireGrant",
+                "kms:ScheduleKeyDeletion",
+                "kms:TagResource",
+                "kms:UpdateAlias"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "DeletesUngated",
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:DeleteAutoScalingGroup",
+                "ec2:DeleteFlowLogs",
+                "ec2:DeleteLaunchTemplate",
+                "ec2:DeleteSecurityGroup",
+                "eks:DeleteCluster",
+                "eks:DeleteNodegroup",
+                "elasticfilesystem:DeleteAccessPoint",
+                "elasticfilesystem:DeleteFileSystem",
+                "elasticfilesystem:DeleteMountTarget",
+                "kms:DeleteAlias",
+                "logs:DeleteLogDelivery",
+                "logs:DeleteLogGroup",
+                "s3:DeleteObjectVersion"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/iam-bootstrap/iam.tf
+++ b/iam-bootstrap/iam.tf
@@ -10,7 +10,18 @@ resource "aws_iam_policy" "deployment" {
 
   name = "${var.deploy_id}-deployment-policy-${count.index}"
 
-  policy = templatefile(abspath(pathexpand(local.iam_policy_paths[count.index])), merge({account_id=data.aws_caller_identity.admin.account_id, deploy_id=var.deploy_id, region=var.region, partition=data.aws_partition.current.partition},var.template_config))
+  policy = templatefile(
+    abspath(pathexpand(local.iam_policy_paths[count.index])),
+    merge(
+      {
+        account_id = data.aws_caller_identity.admin.account_id,
+        deploy_id  = var.deploy_id,
+        region     = var.region,
+        partition  = data.aws_partition.current.partition
+      },
+      var.template_config
+    )
+  )
 }
 
 resource "aws_iam_role" "deployment" {
@@ -24,7 +35,7 @@ resource "aws_iam_role" "deployment" {
         Effect = "Allow"
         Sid    = ""
         Principal = {
-          AWS = "arn:aws:iam::${data.aws_caller_identity.admin.account_id}:root"
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.admin.account_id}:root"
         }
       },
     ]

--- a/iam-bootstrap/iam.tf
+++ b/iam-bootstrap/iam.tf
@@ -1,0 +1,35 @@
+locals {
+  iam_policy_paths = length(var.iam_policy_paths) == 0 ? ["${path.module}/bootstrap-0.json", "${path.module}/bootstrap-1.json"] : var.iam_policy_paths
+}
+
+data "aws_caller_identity" "admin" {}
+
+resource "aws_iam_policy" "deployment" {
+  count = length(local.iam_policy_paths)
+
+  name = "${var.deploy_id}-deployment-policy-${count.index}"
+
+  policy = templatefile(abspath(pathexpand(local.iam_policy_paths[count.index])), merge({account_id=data.aws_caller_identity.admin.account_id, deploy_id=var.deploy_id, region=var.region},var.template_config))
+}
+
+resource "aws_iam_role" "deployment" {
+  name = "${var.deploy_id}-deployment-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.admin.account_id}:root"
+        }
+      },
+    ]
+  })
+
+  managed_policy_arns = aws_iam_policy.deployment[*].arn
+
+  max_session_duration = var.max_session_duration
+}

--- a/iam-bootstrap/iam.tf
+++ b/iam-bootstrap/iam.tf
@@ -3,13 +3,14 @@ locals {
 }
 
 data "aws_caller_identity" "admin" {}
+data "aws_partition" "current" {}
 
 resource "aws_iam_policy" "deployment" {
   count = length(local.iam_policy_paths)
 
   name = "${var.deploy_id}-deployment-policy-${count.index}"
 
-  policy = templatefile(abspath(pathexpand(local.iam_policy_paths[count.index])), merge({account_id=data.aws_caller_identity.admin.account_id, deploy_id=var.deploy_id, region=var.region},var.template_config))
+  policy = templatefile(abspath(pathexpand(local.iam_policy_paths[count.index])), merge({account_id=data.aws_caller_identity.admin.account_id, deploy_id=var.deploy_id, region=var.region, partition=data.aws_partition.current.partition},var.template_config))
 }
 
 resource "aws_iam_role" "deployment" {

--- a/iam-bootstrap/outputs.tf
+++ b/iam-bootstrap/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  description = "ARN of bootstrap role"
+  value       = aws_iam_role.deployment.arn
+}

--- a/iam-bootstrap/render.sh
+++ b/iam-bootstrap/render.sh
@@ -2,6 +2,7 @@
 
 export deploy_id=example
 export account_id=1234567890
+export partition=aws
 
 echo "Rendering bootstrap-*.json to bootstrap-render-*.json..."
 cat bootstrap-0.json | envsubst > bootstrap-rendered-0.json

--- a/iam-bootstrap/render.sh
+++ b/iam-bootstrap/render.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export deploy_id=example
+export account_id=1234567890
+
+echo "Rendering bootstrap-*.json to bootstrap-render-*.json..."
+cat bootstrap-0.json | envsubst > bootstrap-rendered-0.json
+cat bootstrap-1.json | envsubst > bootstrap-rendered-1.json

--- a/iam-bootstrap/variables.tf
+++ b/iam-bootstrap/variables.tf
@@ -21,7 +21,7 @@ variable "iam_policy_paths" {
 
 variable "template_config" {
   type        = map
-  description = "Variables to use for any templating in the IAM policies. AWS account ID (as 'account_id'), deploy_id and region are automatically included."
+  description = "Variables to use for any templating in the IAM policies. AWS account ID (as 'account_id'), deploy_id, region and partition are automatically included."
   default     = {}
 }
 

--- a/iam-bootstrap/variables.tf
+++ b/iam-bootstrap/variables.tf
@@ -1,0 +1,32 @@
+variable "deploy_id" {
+  type        = string
+  description = "Domino Deployment ID"
+
+  validation {
+    condition     = can(regex("^[a-z-0-9]{3,32}$", var.deploy_id))
+    error_message = "Argument deploy_id must: start with a letter, contain lowercase alphanumeric characters(can contain hyphens[-]) with length between 3 and 32 characters."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region for the deployment"
+}
+
+variable "iam_policy_paths" {
+  type        = list(any)
+  description = "IAM policies to provision and use for deployment role, can be terraform templates"
+  default     = []
+}
+
+variable "template_config" {
+  type        = map
+  description = "Variables to use for any templating in the IAM policies. AWS account ID (as 'account_id'), deploy_id and region are automatically included."
+  default     = {}
+}
+
+variable "max_session_duration" {
+  type        = number
+  description = "Maximum session duration for role in seconds"
+  default     = 43200
+}

--- a/iam-bootstrap/versions.tf
+++ b/iam-bootstrap/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}


### PR DESCRIPTION
* Policies meant to be deployed and used separate from the main module
* End users / deploy engineers would provision the module (or manually provision the policies), manually assume the role (or use an associated user they've created) and then provision the main EKS module
* The main EKS module doesn't have any interaction with the policy, as it does not need to know about it
* See https://github.com/cerebrotech/platform-apps/pull/6505 for the internal deployer automation for this