### PR TITLE
PLAT-6183: Setup containerd certs directory on GPU nodes

### DIFF
--- a/submodules/eks/node-group.tf
+++ b/submodules/eks/node-group.tf
@@ -87,7 +87,7 @@ resource "aws_launch_template" "node_groups" {
   name                    = "${local.eks_cluster_name}-${each.key}"
   disable_api_termination = false
   key_name                = var.ssh_key_pair_name
-  user_data = each.value.ami == null ? null : base64encode(templatefile(
+  user_data = each.value.ami == null ? local.any_gpu[each.key] ? base64encode(file("${path.module}/templates/gpu_cert_setup.tpl")) : null : base64encode(templatefile(
     "${path.module}/templates/linux_user_data.tpl",
     {
       # https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-custom-ami

--- a/submodules/eks/templates/gpu_cert_setup.tpl
+++ b/submodules/eks/templates/gpu_cert_setup.tpl
@@ -1,0 +1,16 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
+
+--==MYBOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+
+!/bin/bash
+set -ex
+EKS_CONTAINERD_CFG="/etc/eks/containerd/containerd-config.toml"
+if [ -z "$(egrep 'certs\.d' $EKS_CONTAINERD_CFG)" ]; then
+    if [ -n "$(egrep 'plugins\.cri\.containerd\.runtimes\.nvidia' $EKS_CONTAINERD_CFG)" ]; then
+        printf '\n\n[plugins.cri.registry]\nconfig_path = "/etc/containerd/certs.d:/etc/docker/certs.d"\n' >> $EKS_CONTAINERD_CFG
+    fi
+fi
+
+--==MYBOUNDARY==--\

--- a/submodules/eks/templates/linux_user_data.tpl
+++ b/submodules/eks/templates/linux_user_data.tpl
@@ -6,5 +6,11 @@ export SERVICE_IPV4_CIDR=${cluster_service_ipv4_cidr}
 %{ endif ~}
 B64_CLUSTER_CA=${cluster_auth_base64}
 API_SERVER_URL=${cluster_endpoint}
+EKS_CONTAINERD_CFG="/etc/eks/containerd/containerd-config.toml"
+if [ -z "$(egrep 'certs\.d' $EKS_CONTAINERD_CFG)" ]; then
+    if [ -n "$(egrep 'plugins\.cri\.containerd\.runtimes\.nvidia' $EKS_CONTAINERD_CFG)" ]; then
+        printf '\n\n[plugins.cri.registry]\nconfig_path = "/etc/containerd/certs.d:/etc/docker/certs.d"\n' >> $EKS_CONTAINERD_CFG
+    fi
+fi
 /etc/eks/bootstrap.sh ${cluster_name} ${bootstrap_extra_args} --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL
 ${post_bootstrap_user_data ~}


### PR DESCRIPTION
Although the regular EKS ami sets up containerd with some cert directories, the GPU EKS ami does not.

This either adds a part before the default user data to set that up when no AMI was specified, or adds the same code to our custom user data for custom AMIs.