### PR TITLE
PLAT-6183: Update gpu ami remediation

### DIFF
--- a/submodules/eks/templates/gpu_cert_setup.tpl
+++ b/submodules/eks/templates/gpu_cert_setup.tpl
@@ -7,10 +7,9 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 !/bin/bash
 set -ex
 EKS_CONTAINERD_CFG="/etc/eks/containerd/containerd-config.toml"
-if [ -z "$(egrep 'certs\.d' $EKS_CONTAINERD_CFG)" ]; then
-    if [ -n "$(egrep 'plugins\.cri\.containerd\.runtimes\.nvidia' $EKS_CONTAINERD_CFG)" ]; then
-        printf '\n\n[plugins.cri.registry]\nconfig_path = "/etc/containerd/certs.d:/etc/docker/certs.d"\n' >> $EKS_CONTAINERD_CFG
-    fi
+if [ -n "$(egrep 'plugins\.cri\.containerd\.runtimes\.nvidia' $EKS_CONTAINERD_CFG)" ]; then
+    sed -i 's/plugins\."io.containerd.grpc.v1.cri"\.registry/plugins.cri.registry/' $EKS_CONTAINERD_CFG
 fi
+
 
 --==MYBOUNDARY==--\


### PR DESCRIPTION
They release the fixed GPU ami, however, it was not, in reality, fixed.

See: https://github.com/awslabs/amazon-eks-ami/issues/1154#issuecomment-1414711705

Because the incorrect version of the certs config triggers the safety valve of the old remediation, a new one is needed.