### PR TITLE
enable ECR force destroy for CircleCI testing

### DIFF
--- a/tests/main.tf.json
+++ b/tests/main.tf.json
@@ -34,6 +34,7 @@
           "okta-fulladmin"
         ],
         "s3_force_destroy_on_deletion": true,
+        "ecr_force_destroy_on_deletion": true,
         "bastion": {},
         "ssh_pvt_key_path": "domino.pem",
         "tags": "${var.tags}",


### PR DESCRIPTION
Enable ECR force destroy so there's no dangling repos in the tests.

https://github.com/dominodatalab/terraform-aws-eks/pull/27#discussion_r1096248209