### PR TITLE
PLAT-5668: Minor conversion process tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ aws s3 rb s3://"${AWS_TERRAFORM_REMOTE_STATE_BUCKET}" --force
 | <a name="input_efs_backup_delete_after"></a> [efs\_backup\_delete\_after](#input\_efs\_backup\_delete\_after) | Delete backup data after this many days | `number` | `125` | no |
 | <a name="input_efs_backup_schedule"></a> [efs\_backup\_schedule](#input\_efs\_backup\_schedule) | Cron-style schedule for EFS backup vault (default: once a day at 12pm) | `string` | `"0 12 * * ? *"` | no |
 | <a name="input_efs_backup_vault_force_destroy"></a> [efs\_backup\_vault\_force\_destroy](#input\_efs\_backup\_vault\_force\_destroy) | Toggle to allow automatic destruction of all backups when destroying. | `bool` | `false` | no |
-| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({rolearn = string, username = string, groups = list(string)}))` | `[]` | no |
+| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({ rolearn = string, username = string, groups = list(string) }))` | `[]` | no |
 | <a name="input_eks_master_role_names"></a> [eks\_master\_role\_names](#input\_eks\_master\_role\_names) | IAM role names to be added as masters in eks. | `list(string)` | `[]` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | EKS cluster k8s version. | `string` | `"1.24"` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | if use\_kms is set, use the specified KMS key | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ aws s3 rb s3://"${AWS_TERRAFORM_REMOTE_STATE_BUCKET}" --force
 | <a name="input_efs_backup_delete_after"></a> [efs\_backup\_delete\_after](#input\_efs\_backup\_delete\_after) | Delete backup data after this many days | `number` | `125` | no |
 | <a name="input_efs_backup_schedule"></a> [efs\_backup\_schedule](#input\_efs\_backup\_schedule) | Cron-style schedule for EFS backup vault (default: once a day at 12pm) | `string` | `"0 12 * * ? *"` | no |
 | <a name="input_efs_backup_vault_force_destroy"></a> [efs\_backup\_vault\_force\_destroy](#input\_efs\_backup\_vault\_force\_destroy) | Toggle to allow automatic destruction of all backups when destroying. | `bool` | `false` | no |
+| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({rolearn = string, username = string, groups = list(string)}))` | `[]` | no |
 | <a name="input_eks_master_role_names"></a> [eks\_master\_role\_names](#input\_eks\_master\_role\_names) | IAM role names to be added as masters in eks. | `list(string)` | `[]` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | EKS cluster k8s version. | `string` | `"1.24"` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | if use\_kms is set, use the specified KMS key | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -199,6 +199,7 @@ module "eks" {
   bastion_public_ip            = try(module.bastion[0].public_ip, "")
   secrets_kms_key              = local.kms_key_arn
   node_groups_kms_key          = local.kms_key_arn
+  eks_custom_role_maps         = var.eks_custom_role_maps
 
   depends_on = [
     module.network

--- a/submodules/eks/README.md
+++ b/submodules/eks/README.md
@@ -70,6 +70,7 @@
 | <a name="input_deploy_id"></a> [deploy\_id](#input\_deploy\_id) | Domino Deployment ID | `string` | n/a | yes |
 | <a name="input_efs_security_group"></a> [efs\_security\_group](#input\_efs\_security\_group) | Security Group ID for EFS | `string` | n/a | yes |
 | <a name="input_eks_cluster_addons"></a> [eks\_cluster\_addons](#input\_eks\_cluster\_addons) | EKS cluster addons. vpc-cni is installed separately. | `list(string)` | <pre>[<br>  "kube-proxy",<br>  "coredns"<br>]</pre> | no |
+| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({rolearn = string, username = string, groups = list(string)}))` | n/a | yes |
 | <a name="input_eks_master_role_names"></a> [eks\_master\_role\_names](#input\_eks\_master\_role\_names) | IAM role names to be added as masters in eks | `list(string)` | `[]` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | EKS cluster k8s version. | `string` | n/a | yes |
 | <a name="input_kubeconfig_path"></a> [kubeconfig\_path](#input\_kubeconfig\_path) | Kubeconfig file path. | `string` | `"kubeconfig"` | no |

--- a/submodules/eks/README.md
+++ b/submodules/eks/README.md
@@ -70,7 +70,7 @@
 | <a name="input_deploy_id"></a> [deploy\_id](#input\_deploy\_id) | Domino Deployment ID | `string` | n/a | yes |
 | <a name="input_efs_security_group"></a> [efs\_security\_group](#input\_efs\_security\_group) | Security Group ID for EFS | `string` | n/a | yes |
 | <a name="input_eks_cluster_addons"></a> [eks\_cluster\_addons](#input\_eks\_cluster\_addons) | EKS cluster addons. vpc-cni is installed separately. | `list(string)` | <pre>[<br>  "kube-proxy",<br>  "coredns"<br>]</pre> | no |
-| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({ rolearn = string, username = string, groups = list(string) }))` | n/a | yes |
+| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({ rolearn = string, username = string, groups = list(string) }))` | `[]` | no |
 | <a name="input_eks_master_role_names"></a> [eks\_master\_role\_names](#input\_eks\_master\_role\_names) | IAM role names to be added as masters in eks | `list(string)` | `[]` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | EKS cluster k8s version. | `string` | n/a | yes |
 | <a name="input_kubeconfig_path"></a> [kubeconfig\_path](#input\_kubeconfig\_path) | Kubeconfig file path. | `string` | `"kubeconfig"` | no |

--- a/submodules/eks/README.md
+++ b/submodules/eks/README.md
@@ -70,7 +70,7 @@
 | <a name="input_deploy_id"></a> [deploy\_id](#input\_deploy\_id) | Domino Deployment ID | `string` | n/a | yes |
 | <a name="input_efs_security_group"></a> [efs\_security\_group](#input\_efs\_security\_group) | Security Group ID for EFS | `string` | n/a | yes |
 | <a name="input_eks_cluster_addons"></a> [eks\_cluster\_addons](#input\_eks\_cluster\_addons) | EKS cluster addons. vpc-cni is installed separately. | `list(string)` | <pre>[<br>  "kube-proxy",<br>  "coredns"<br>]</pre> | no |
-| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({rolearn = string, username = string, groups = list(string)}))` | n/a | yes |
+| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({ rolearn = string, username = string, groups = list(string) }))` | n/a | yes |
 | <a name="input_eks_master_role_names"></a> [eks\_master\_role\_names](#input\_eks\_master\_role\_names) | IAM role names to be added as masters in eks | `list(string)` | `[]` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | EKS cluster k8s version. | `string` | n/a | yes |
 | <a name="input_kubeconfig_path"></a> [kubeconfig\_path](#input\_kubeconfig\_path) | Kubeconfig file path. | `string` | `"kubeconfig"` | no |

--- a/submodules/eks/k8s.tf
+++ b/submodules/eks/k8s.tf
@@ -13,6 +13,7 @@ module "k8s_setup" {
   eks_node_role_arns   = [aws_iam_role.eks_nodes.arn]
   eks_master_role_arns = [for r in concat(values(data.aws_iam_role.eks_master_roles), [aws_iam_role.eks_cluster]) : r.arn]
   kubeconfig_path      = var.kubeconfig_path
+  eks_custom_role_maps = var.eks_custom_role_maps
 
   security_group_id = aws_security_group.eks_nodes.id
   pod_subnets       = var.pod_subnets

--- a/submodules/eks/node-group.tf
+++ b/submodules/eks/node-group.tf
@@ -22,6 +22,10 @@ resource "aws_security_group" "eks_nodes" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+        name,
+        description
+    ]
   }
   tags = {
     "Name"                                            = "${local.eks_cluster_name}-eks-nodes"

--- a/submodules/eks/node-group.tf
+++ b/submodules/eks/node-group.tf
@@ -23,8 +23,8 @@ resource "aws_security_group" "eks_nodes" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
-        name,
-        description
+      name,
+      description
     ]
   }
   tags = {

--- a/submodules/eks/variables.tf
+++ b/submodules/eks/variables.tf
@@ -144,3 +144,8 @@ variable "node_groups_kms_key" {
   description = "if set, use specified key for the EKS node groups"
   default     = null
 }
+
+variable "eks_custom_role_maps" {
+  type        = list(object({rolearn = string, username = string, groups = list(string)}))
+  description = "Custom role maps for aws auth configmap"
+}

--- a/submodules/eks/variables.tf
+++ b/submodules/eks/variables.tf
@@ -146,6 +146,6 @@ variable "node_groups_kms_key" {
 }
 
 variable "eks_custom_role_maps" {
-  type        = list(object({rolearn = string, username = string, groups = list(string)}))
+  type        = list(object({ rolearn = string, username = string, groups = list(string) }))
   description = "Custom role maps for aws auth configmap"
 }

--- a/submodules/eks/variables.tf
+++ b/submodules/eks/variables.tf
@@ -148,4 +148,5 @@ variable "node_groups_kms_key" {
 variable "eks_custom_role_maps" {
   type        = list(object({ rolearn = string, username = string, groups = list(string) }))
   description = "Custom role maps for aws auth configmap"
+  default     = []
 }

--- a/submodules/k8s/README.md
+++ b/submodules/k8s/README.md
@@ -36,7 +36,7 @@ No modules.
 | <a name="input_bastion_user"></a> [bastion\_user](#input\_bastion\_user) | ec2 instance user. | `string` | `"ec2-user"` | no |
 | <a name="input_calico_version"></a> [calico\_version](#input\_calico\_version) | Calico operator version. | `string` | `"v1.11.0"` | no |
 | <a name="input_eks_cluster_arn"></a> [eks\_cluster\_arn](#input\_eks\_cluster\_arn) | ARN of the EKS cluster | `string` | n/a | yes |
-| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({rolearn = string, username = string, groups = list(string)}))` | n/a | yes |
+| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({ rolearn = string, username = string, groups = list(string) }))` | n/a | yes |
 | <a name="input_eks_master_role_arns"></a> [eks\_master\_role\_arns](#input\_eks\_master\_role\_arns) | IAM role arns to be added as masters in eks. | `list(string)` | `[]` | no |
 | <a name="input_eks_node_role_arns"></a> [eks\_node\_role\_arns](#input\_eks\_node\_role\_arns) | Roles arns for EKS nodes to be added to aws-auth for api auth. | `list(string)` | n/a | yes |
 | <a name="input_k8s_tunnel_port"></a> [k8s\_tunnel\_port](#input\_k8s\_tunnel\_port) | K8s ssh tunnel port | `string` | `"1080"` | no |

--- a/submodules/k8s/README.md
+++ b/submodules/k8s/README.md
@@ -36,6 +36,7 @@ No modules.
 | <a name="input_bastion_user"></a> [bastion\_user](#input\_bastion\_user) | ec2 instance user. | `string` | `"ec2-user"` | no |
 | <a name="input_calico_version"></a> [calico\_version](#input\_calico\_version) | Calico operator version. | `string` | `"v1.11.0"` | no |
 | <a name="input_eks_cluster_arn"></a> [eks\_cluster\_arn](#input\_eks\_cluster\_arn) | ARN of the EKS cluster | `string` | n/a | yes |
+| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({rolearn = string, username = string, groups = list(string)}))` | n/a | yes |
 | <a name="input_eks_master_role_arns"></a> [eks\_master\_role\_arns](#input\_eks\_master\_role\_arns) | IAM role arns to be added as masters in eks. | `list(string)` | `[]` | no |
 | <a name="input_eks_node_role_arns"></a> [eks\_node\_role\_arns](#input\_eks\_node\_role\_arns) | Roles arns for EKS nodes to be added to aws-auth for api auth. | `list(string)` | n/a | yes |
 | <a name="input_k8s_tunnel_port"></a> [k8s\_tunnel\_port](#input\_k8s\_tunnel\_port) | K8s ssh tunnel port | `string` | `"1080"` | no |

--- a/submodules/k8s/README.md
+++ b/submodules/k8s/README.md
@@ -36,7 +36,7 @@ No modules.
 | <a name="input_bastion_user"></a> [bastion\_user](#input\_bastion\_user) | ec2 instance user. | `string` | `"ec2-user"` | no |
 | <a name="input_calico_version"></a> [calico\_version](#input\_calico\_version) | Calico operator version. | `string` | `"v1.11.0"` | no |
 | <a name="input_eks_cluster_arn"></a> [eks\_cluster\_arn](#input\_eks\_cluster\_arn) | ARN of the EKS cluster | `string` | n/a | yes |
-| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({ rolearn = string, username = string, groups = list(string) }))` | n/a | yes |
+| <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({ rolearn = string, username = string, groups = list(string) }))` | `[]` | no |
 | <a name="input_eks_master_role_arns"></a> [eks\_master\_role\_arns](#input\_eks\_master\_role\_arns) | IAM role arns to be added as masters in eks. | `list(string)` | `[]` | no |
 | <a name="input_eks_node_role_arns"></a> [eks\_node\_role\_arns](#input\_eks\_node\_role\_arns) | Roles arns for EKS nodes to be added to aws-auth for api auth. | `list(string)` | n/a | yes |
 | <a name="input_k8s_tunnel_port"></a> [k8s\_tunnel\_port](#input\_k8s\_tunnel\_port) | K8s ssh tunnel port | `string` | `"1080"` | no |

--- a/submodules/k8s/main.tf
+++ b/submodules/k8s/main.tf
@@ -45,6 +45,7 @@ locals {
         {
           eks_node_role_arns   = toset(var.eks_node_role_arns)
           eks_master_role_arns = toset(var.eks_master_role_arns)
+          eks_custom_role_maps = var.eks_custom_role_maps
       })
 
     }

--- a/submodules/k8s/templates/aws-auth.yaml.tftpl
+++ b/submodules/k8s/templates/aws-auth.yaml.tftpl
@@ -18,3 +18,6 @@ data:
       groups:
         - system:masters
 %{ endfor ~}
+%{ for rolemap in eks_custom_role_maps ~}
+    - ${jsonencode(rolemap)}
+%{ endfor ~}

--- a/submodules/k8s/variables.tf
+++ b/submodules/k8s/variables.tf
@@ -59,3 +59,8 @@ variable "pod_subnets" {
   type        = list(object({ subnet_id = string, az = string }))
   description = "Pod subnets and az to setup with vpc-cni"
 }
+
+variable "eks_custom_role_maps" {
+  type        = list(object({rolearn = string, username = string, groups = list(string)}))
+  description = "Custom role maps for aws auth configmap"
+}

--- a/submodules/k8s/variables.tf
+++ b/submodules/k8s/variables.tf
@@ -63,4 +63,5 @@ variable "pod_subnets" {
 variable "eks_custom_role_maps" {
   type        = list(object({ rolearn = string, username = string, groups = list(string) }))
   description = "Custom role maps for aws auth configmap"
+  default     = []
 }

--- a/submodules/k8s/variables.tf
+++ b/submodules/k8s/variables.tf
@@ -61,6 +61,6 @@ variable "pod_subnets" {
 }
 
 variable "eks_custom_role_maps" {
-  type        = list(object({rolearn = string, username = string, groups = list(string)}))
+  type        = list(object({ rolearn = string, username = string, groups = list(string) }))
   description = "Custom role maps for aws auth configmap"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -353,3 +353,9 @@ variable "efs_backup_delete_after" {
   description = "Delete backup data after this many days"
   default     = 125
 }
+
+variable "eks_custom_role_maps" {
+  type        = list(object({rolearn = string, username = string, groups = list(string)}))
+  description = "Custom role maps for aws auth configmap"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -355,7 +355,7 @@ variable "efs_backup_delete_after" {
 }
 
 variable "eks_custom_role_maps" {
-  type        = list(object({rolearn = string, username = string, groups = list(string)}))
+  type        = list(object({ rolearn = string, username = string, groups = list(string) }))
   description = "Custom role maps for aws auth configmap"
   default     = []
 }


### PR DESCRIPTION
* Don't recreate node security group just because of name/description
* Allow custom aws-auth map role entries
  * Allows us to use original nodegroup iam role so we don't break OG ASGs prior to switchover
  * Mainly for peace of mind (Domino isn't suddenly down)