### PR TITLE
avoid bumping the launch template for no-op changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ aws s3 rb s3://"${AWS_TERRAFORM_REMOTE_STATE_BUCKET}" --force
 | [aws_kms_key.domino](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.aws_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_default_tags.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_ec2_instance_type.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_instance_type) | data source |
 | [aws_ec2_instance_type_offerings.nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_instance_type_offerings) | data source |
 | [aws_iam_policy_document.kms_key_global](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/main.tf
+++ b/main.tf
@@ -162,12 +162,15 @@ module "bastion" {
   }
 }
 
+data "aws_default_tags" "this" {}
+
 locals {
   node_groups = {
     for name, ng in
     merge(var.additional_node_groups, var.default_node_groups) :
     name => merge(ng, {
-      gpu = ng.gpu != null ? ng.gpu : anytrue([for itype in ng.instance_types : length(data.aws_ec2_instance_type.all[itype].gpus) > 0]),
+      gpu           = ng.gpu != null ? ng.gpu : anytrue([for itype in ng.instance_types : length(data.aws_ec2_instance_type.all[itype].gpus) > 0]),
+      instance_tags = merge(data.aws_default_tags.this.tags, ng.tags)
     })
   }
 }

--- a/submodules/eks/README.md
+++ b/submodules/eks/README.md
@@ -48,7 +48,6 @@
 | [aws_security_group_rule.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [null_resource.kubeconfig](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_caller_identity.aws_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_default_tags.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_iam_policy_document.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.custom_eks_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/submodules/eks/node-group.tf
+++ b/submodules/eks/node-group.tf
@@ -75,8 +75,6 @@ locals {
   node_groups_by_name = { for ngz in local.node_groups_per_zone : "${ngz.ng_name}-${ngz.sb_name}" => ngz }
 }
 
-data "aws_default_tags" "this" {}
-
 resource "aws_launch_template" "node_groups" {
   for_each                = var.node_groups
   name                    = "${local.eks_cluster_name}-${each.key}"
@@ -122,7 +120,7 @@ resource "aws_launch_template" "node_groups" {
     for_each = toset(["instance", "volume"])
     content {
       resource_type = tag_specifications.value
-      tags = merge(data.aws_default_tags.this.tags, each.value.tags, {
+      tags = merge(each.value.instance_tags, each.value.tags, {
         "Name" = "${local.eks_cluster_name}-${each.key}"
       })
     }


### PR DESCRIPTION
aws_default_tags isn't resolved within the module so the launch template version is bumped regardless of whether there was actually a tag change. this then causes the node group to update and all nodes to roll.