### PR TITLE
PLAT-6336 Update Calico install manifests.

### DIFF
--- a/submodules/k8s/README.md
+++ b/submodules/k8s/README.md
@@ -34,7 +34,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bastion_public_ip"></a> [bastion\_public\_ip](#input\_bastion\_public\_ip) | Bastion host public ip. | `string` | n/a | yes |
 | <a name="input_bastion_user"></a> [bastion\_user](#input\_bastion\_user) | ec2 instance user. | `string` | `"ec2-user"` | no |
-| <a name="input_calico_version"></a> [calico\_version](#input\_calico\_version) | Calico operator version. | `string` | `"v1.11.0"` | no |
+| <a name="input_calico_version"></a> [calico\_version](#input\_calico\_version) | Calico operator version. | `string` | `"v3.25.0"` | no |
 | <a name="input_eks_cluster_arn"></a> [eks\_cluster\_arn](#input\_eks\_cluster\_arn) | ARN of the EKS cluster | `string` | n/a | yes |
 | <a name="input_eks_custom_role_maps"></a> [eks\_custom\_role\_maps](#input\_eks\_custom\_role\_maps) | Custom role maps for aws auth configmap | `list(object({ rolearn = string, username = string, groups = list(string) }))` | `[]` | no |
 | <a name="input_eks_master_role_arns"></a> [eks\_master\_role\_arns](#input\_eks\_master\_role\_arns) | IAM role arns to be added as masters in eks. | `list(string)` | `[]` | no |

--- a/submodules/k8s/main.tf
+++ b/submodules/k8s/main.tf
@@ -8,8 +8,7 @@ locals {
   eniconfig_filename        = length(var.pod_subnets) != 0 ? "eniconfig.yaml" : ""
   eniconfig_template        = "eniconfig.yaml.tftpl"
   calico = {
-    operator_url         = "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/${var.calico_version}/config/master/calico-operator.yaml"
-    custom_resources_url = "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/${var.calico_version}/config/master/calico-crs.yaml"
+    operator_url = "https://raw.githubusercontent.com/projectcalico/calico/${var.calico_version}/manifests/tigera-operator.yaml"
   }
 
   resources_directory = path.cwd
@@ -19,16 +18,15 @@ locals {
     k8s_functions_sh = {
       filename = local.k8s_functions_sh_filename
       content = templatefile("${local.templates_dir}/${local.k8s_functions_sh_template}", {
-        kubeconfig_path             = var.kubeconfig_path
-        k8s_tunnel_port             = var.k8s_tunnel_port
-        aws_auth_yaml               = basename(local.aws_auth_filename)
-        eniconfig_yaml              = local.eniconfig_filename != "" ? basename(local.eniconfig_filename) : ""
-        calico_operator_url         = local.calico.operator_url
-        calico_custom_resources_url = local.calico.custom_resources_url
-        bastion_user                = var.bastion_user
-        bastion_public_ip           = var.bastion_public_ip
-        ssh_pvt_key_path            = var.ssh_pvt_key_path
-        eks_cluster_arn             = var.eks_cluster_arn
+        kubeconfig_path     = var.kubeconfig_path
+        k8s_tunnel_port     = var.k8s_tunnel_port
+        aws_auth_yaml       = basename(local.aws_auth_filename)
+        eniconfig_yaml      = local.eniconfig_filename != "" ? basename(local.eniconfig_filename) : ""
+        calico_operator_url = local.calico.operator_url
+        bastion_user        = var.bastion_user
+        bastion_public_ip   = var.bastion_public_ip
+        ssh_pvt_key_path    = var.ssh_pvt_key_path
+        eks_cluster_arn     = var.eks_cluster_arn
       })
     }
 

--- a/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -39,7 +39,7 @@ set_k8s_auth() {
 set_eniconfig() {
   local ENICONFIG_YAML="${eniconfig_yaml}"
   if [ -z "$ENICONFIG_YAML" ]; then
-      return
+    return
   fi
   if test -f "$ENICONFIG_YAML"; then
     printf "$GREEN Updating $ENICONFIG_YAML... $EC \n"
@@ -54,11 +54,22 @@ set_eniconfig() {
 install_calico() {
   local CALICO_OPERATOR_YAML_URL=${calico_operator_url}
   printf "$GREEN Installing Calico Operator $EC \n"
-  kubectl_apply $CALICO_OPERATOR_YAML_URL
+  ## Workaround for https://github.com/projectcalico/calico/issues/6491#issuecomment-1253970628
+  (kubectl_cmd create -f $CALICO_OPERATOR_YAML_URL) || true
+  kubectl_cmd replace -f $CALICO_OPERATOR_YAML_URL
   echo
-  local CALICO_CRD_YAML_URL=${calico_custom_resources_url}
+
   printf "$GREEN Installing Calico Custom resources $EC \n"
-  kubectl_apply $CALICO_CRD_YAML_URL
+  kubectl_cmd create -f - <<EOF
+kind: Installation
+apiVersion: operator.tigera.io/v1
+metadata:
+  name: default
+spec:
+  kubernetesProvider: EKS
+  cni:
+    type: AmazonVPC
+EOF
   echo
 }
 
@@ -91,7 +102,7 @@ kubectl_cmd() {
   echo "Running kubectl $@..."
   kubectl --kubeconfig "$KUBECONFIG_PROXY" $@
   if [ $? -ne 0 ]; then
-    printf "$RED Error running kubectl $@ \n"
+    printf "$RED Error running kubectl $@ $EC \n"
     exit 1
   fi
 }

--- a/submodules/k8s/variables.tf
+++ b/submodules/k8s/variables.tf
@@ -47,7 +47,7 @@ variable "k8s_tunnel_port" {
 variable "calico_version" {
   type        = string
   description = "Calico operator version."
-  default     = "v1.11.0"
+  default     = "v3.25.0"
 }
 
 variable "security_group_id" {


### PR DESCRIPTION
Updates the calico manifests as they are being removed from the aws repo,https://github.com/aws/amazon-vpc-cni-k8s/issues/2287
Also needed to support eks 1.25,[PLAT-6342](https://dominodatalab.atlassian.net/browse/PLAT-6342)