### PR TITLE
Trigger setup script on all component changes

### DIFF
--- a/submodules/k8s/main.tf
+++ b/submodules/k8s/main.tf
@@ -69,7 +69,10 @@ resource "local_file" "templates" {
 
 resource "null_resource" "run_k8s_pre_setup" {
   triggers = {
-    script_hash = md5(local_file.templates["k8s_presetup"].content)
+    k8s_presetup_hash     = md5(local_file.templates["k8s_presetup"].content)
+    k8s_functions_sh_hash = md5(local_file.templates["k8s_functions_sh"].content)
+    aws_auth_hash         = md5(local_file.templates["aws_auth"].content)
+    eni_config_hash       = md5(local_file.templates["eni_config"].content)
   }
 
   provisioner "local-exec" {

--- a/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -56,11 +56,11 @@ install_calico() {
   printf "$GREEN Installing Calico Operator $EC \n"
   ## Workaround for https://github.com/projectcalico/calico/issues/6491#issuecomment-1253970628
   (kubectl_cmd create -f $CALICO_OPERATOR_YAML_URL) || true
-  kubectl_cmd replace --force -f $CALICO_OPERATOR_YAML_URL
+  kubectl_cmd replace -f $CALICO_OPERATOR_YAML_URL
   echo
 
   printf "$GREEN Installing Calico Custom resources $EC \n"
-  kubectl_cmd create -f - <<EOF
+  kubectl_cmd apply -f - <<EOF
 kind: Installation
 apiVersion: operator.tigera.io/v1
 metadata:

--- a/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -60,7 +60,7 @@ install_calico() {
   echo
 
   printf "$GREEN Installing Calico Custom resources $EC \n"
-  kubectl_apply - <<EOF
+  kubectl_cmd apply -f - <<EOF
 kind: Installation
 apiVersion: operator.tigera.io/v1
 metadata:

--- a/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -60,7 +60,7 @@ install_calico() {
   echo
 
   printf "$GREEN Installing Calico Custom resources $EC \n"
-  kubectl_cmd apply -f - <<EOF
+  kubectl_apply - <<EOF
 kind: Installation
 apiVersion: operator.tigera.io/v1
 metadata:

--- a/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -56,7 +56,7 @@ install_calico() {
   printf "$GREEN Installing Calico Operator $EC \n"
   ## Workaround for https://github.com/projectcalico/calico/issues/6491#issuecomment-1253970628
   (kubectl_cmd create -f $CALICO_OPERATOR_YAML_URL) || true
-  kubectl_cmd replace -f $CALICO_OPERATOR_YAML_URL
+  kubectl_cmd replace --force -f $CALICO_OPERATOR_YAML_URL
   echo
 
   printf "$GREEN Installing Calico Custom resources $EC \n"


### PR DESCRIPTION
Because we don't trigger re-running the setup script on all script/yaml updates, but still do on the root script, in situations where we make changes in the accompanying files we are basically kicking the can down the road to find all the places we broke upgrade compatibility.

In this case, it seems like we broke upgrade compatibility with calico on the recent calico change.