### PR TITLE
switch to OIDC for AWS credentials in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,6 @@ jobs:
     steps:
       - checkout
       - install_tf
-      - run: |
-          echo "export AWS_ACCESS_KEY_ID=" >> $BASH_ENV
-          echo "export AWS_SECRET_ACCESS_KEY=" >> $BASH_ENV
       - aws-cli/setup:
          role-arn: "${AWS_IAM_ROLE}"
       - set_env_vars
@@ -109,9 +106,6 @@ jobs:
     steps:
       - checkout
       - install_tf
-      - run: |
-          echo "export AWS_ACCESS_KEY_ID=" >> $BASH_ENV
-          echo "export AWS_SECRET_ACCESS_KEY=" >> $BASH_ENV
       - aws-cli/setup:
          role-arn: "${AWS_IAM_ROLE}"
       - set_env_vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ commands:
           command: ssh-keygen -q -P '' -t rsa -b 4096 -m PEM -f tests/domino.pem
   tf_init_apply:
     steps:
+      - aws-cli/setup:
+         role-arn: "${AWS_IAM_ROLE}"
       - run:
           name: Terraform init/validate/apply
           working_directory: tests
@@ -52,6 +54,8 @@ commands:
             terraform apply -auto-approve
   tf_destroy:
     steps:
+      - aws-cli/setup:
+         role-arn: "${AWS_IAM_ROLE}"
       - run:
           name: Terraform destroy
           working_directory: tests
@@ -85,8 +89,6 @@ jobs:
     steps:
       - checkout
       - install_tf
-      - aws-cli/setup:
-         role-arn: "${AWS_IAM_ROLE}"
       - set_env_vars
       - gen_pvt_key
       - tf_init_apply
@@ -121,6 +123,8 @@ jobs:
             echo "Setting module source to: ${MOD_SOURCE}"
             cat \<<< $(jq --arg mod_source "${MOD_SOURCE}" '.module[0].domino_eks.source = $mod_source' main.tf.json) >main.tf.json
       - tf_init_apply
+      - aws-cli/setup:
+         role-arn: "${AWS_IAM_ROLE}"
       - run:
           name: "Upgrade module by applying this commit"
           working_directory: tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ parameters:
 
 orbs:
   terraform: circleci/terraform@3.2.0
+  aws-cli: circleci/aws-cli@3.1
 
 commands:
   set_env_vars:
@@ -84,6 +85,11 @@ jobs:
     steps:
       - checkout
       - install_tf
+      - run: |
+          echo "export AWS_ACCESS_KEY_ID=" >> $BASH_ENV
+          echo "export AWS_SECRET_ACCESS_KEY=" >> $BASH_ENV
+      - aws-cli/setup:
+         role-arn: "${AWS_IAM_ROLE}"
       - set_env_vars
       - gen_pvt_key
       - tf_init_apply
@@ -103,6 +109,11 @@ jobs:
     steps:
       - checkout
       - install_tf
+      - run: |
+          echo "export AWS_ACCESS_KEY_ID=" >> $BASH_ENV
+          echo "export AWS_SECRET_ACCESS_KEY=" >> $BASH_ENV
+      - aws-cli/setup:
+         role-arn: "${AWS_IAM_ROLE}"
       - set_env_vars
       - gen_pvt_key
       - run:
@@ -136,10 +147,12 @@ workflows:
       equal: ["test-deploy-workflow", << pipeline.parameters.GHA_Action >> ]
     jobs:
       - test-deploy:
+          context: aws-oidc
           terraform_version: << pipeline.parameters.terraform_version >>
   test-upgrade-workflow:
     when:
       equal: ["test-upgrade-workflow", << pipeline.parameters.GHA_Action >> ]
     jobs:
       - test-upgrade:
+          context: aws-oidc
           terraform_version: << pipeline.parameters.terraform_version >>


### PR DESCRIPTION
Static credentials have a tendency to get stale and OIDC was relatively straightforward to setup. I'll remove the static keys from CircleCI once this is merged.