### PR TITLE
lookup custom AMI root device name for node groups

### DIFF
--- a/submodules/eks/README.md
+++ b/submodules/eks/README.md
@@ -47,6 +47,7 @@
 | [aws_security_group_rule.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [null_resource.kubeconfig](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_ami.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.aws_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ec2_instance_type_offerings.nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_instance_type_offerings) | data source |
 | [aws_iam_policy_document.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/submodules/eks/node-group.tf
+++ b/submodules/eks/node-group.tf
@@ -92,6 +92,15 @@ locals {
   node_groups_by_name = { for ngz in local.node_groups_per_zone : "${ngz.ng_name}-${ngz.sb_name}" => ngz }
 }
 
+data "aws_ami" "custom" {
+  for_each = toset([for k, v in var.node_groups : v.ami if v.ami != null])
+
+  filter {
+    name   = "image-id"
+    values = [each.value]
+  }
+}
+
 resource "aws_launch_template" "node_groups" {
   for_each                = var.node_groups
   name                    = "${local.eks_cluster_name}-${each.key}"
@@ -115,7 +124,7 @@ resource "aws_launch_template" "node_groups" {
   image_id               = each.value.ami
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = each.value.ami == null ? "/dev/xvda" : data.aws_ami.custom[each.value.ami].root_device_name
 
     ebs {
       delete_on_termination = true

--- a/submodules/eks/node-group.tf
+++ b/submodules/eks/node-group.tf
@@ -124,7 +124,7 @@ resource "aws_launch_template" "node_groups" {
   image_id               = each.value.ami
 
   block_device_mappings {
-    device_name = each.value.ami == null ? "/dev/xvda" : data.aws_ami.custom[each.value.ami].root_device_name
+    device_name = try(data.aws_ami.custom[each.value.ami].root_device_name, "/dev/xvda")
 
     ebs {
       delete_on_termination = true


### PR DESCRIPTION
When using a non-EKS AMI, the root device name can be different than `xvda`.