### PR TITLE
add autoscaling IAM policy requirements

### DIFF
--- a/submodules/eks/iam.tf
+++ b/submodules/eks/iam.tf
@@ -33,13 +33,17 @@ data "aws_iam_policy_document" "autoscaler" {
     actions = [
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeScalingActivities",
       "autoscaling:DescribeTags",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstanceTypes",
       "ec2:DescribeLaunchTemplateVersions",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup"
     ]
   }
 
   statement {
-
     effect    = "Allow"
     resources = ["*"]
 


### PR DESCRIPTION
`eks:DescribeNodegroup` is the main one I think we're missing, but the rest are useful if we ever want to use launch templates with min/max resource requirements instead of instance types.
 
https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.25.0/cluster-autoscaler/cloudprovider/aws/README.md#full-cluster-autoscaler-features-policy-recommended