### PR TITLE
PLAT-6387 registry defaults to docker.io, set to quay

### DIFF
--- a/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -120,6 +120,7 @@ install_calico() {
     --version "${calico_version}" \
     --set installation.kubernetesProvider=EKS \
     --set installation.cni.type=AmazonVPC \
+    --set installation.registry="quay.io/" \
     --timeout 10m \
     --create-namespace \
     --install


### PR DESCRIPTION
As part of [PLAT-6387](https://dominodatalab.atlassian.net/browse/PLAT-6387), we need to set the registry to `quay.io` as we are getting rate limited by `docker.io`.
Setting registry as per [doc](https://docs.tigera.io/calico/latest/reference/installation/api#operator.tigera.io/v1.InstallationSpec).