### PR TITLE
set IdentitiesOnly=yes when SSHing to bastion

### DIFF
--- a/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -13,7 +13,7 @@ open_ssh_tunnel_to_k8s_api() {
     printf "$GREEN Opening k8s tunnel ... $EC \n"
     ssh-keygen -R "${bastion_public_ip}" || true
     chmod 400 "${ssh_pvt_key_path}"
-    ssh -q -N -f -M -o "StrictHostKeyChecking no" -o "ExitOnForwardFailure=yes" -i "${ssh_pvt_key_path}" -D ${k8s_tunnel_port} -S "$TUNNEL_SOCKET_FILE" ${bastion_user}@${bastion_public_ip}
+    ssh -q -N -f -M -o "IdentitiesOnly=yes" -o "StrictHostKeyChecking=no" -o "ExitOnForwardFailure=yes" -i "${ssh_pvt_key_path}" -D ${k8s_tunnel_port} -S "$TUNNEL_SOCKET_FILE" ${bastion_user}@${bastion_public_ip}
   else
     printf "$GREEN No bastion, no tunnel needed... $EC \n"
   fi


### PR DESCRIPTION
Might be a me problem, but if the ssh-agent has too many identities it can cause rate-limit auth failures.