### PR TITLE
support update from refactored network module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,11 @@ locals {
 }
 
 
+moved {
+  from = module.eks.module.network[0]
+  to   = module.eks.module.network
+}
+
 module "network" {
   source              = "./submodules/network"
   deploy_id           = var.deploy_id


### PR DESCRIPTION
[PLAT-6614](https://dominodatalab.atlassian.net/browse/PLAT-6614)
prevent VPC recreation on upgrade from older versions of this module.