### PR TITLE
Address new checkov errors; kubernetes version and cloudwatch log group retention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         args:
           - '--args=--compact'
           - '--args=--quiet'
-          - '--args=--skip-check CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6,CKV2_AWS_11,CKV2_AWS_12,CKV2_AWS_6,CKV_AWS_109,CKV_AWS_111,CKV_AWS_135,CKV_AWS_144,CKV_AWS_145,CKV_AWS_158,CKV_AWS_18,CKV_AWS_184,CKV_AWS_19,CKV_AWS_21,CKV_AWS_66,CKV_AWS_88,CKV2_GHA_1,CKV_AWS_163,CKV_AWS_39,CKV_AWS_38,CKV2_AWS_61,CKV2_AWS_62,CKV_AWS_136'
+          - '--args=--skip-check CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6,CKV2_AWS_11,CKV2_AWS_12,CKV2_AWS_6,CKV_AWS_109,CKV_AWS_111,CKV_AWS_135,CKV_AWS_144,CKV_AWS_145,CKV_AWS_158,CKV_AWS_18,CKV_AWS_184,CKV_AWS_19,CKV_AWS_21,CKV_AWS_66,CKV_AWS_88,CKV2_GHA_1,CKV_AWS_163,CKV_AWS_39,CKV_AWS_38,CKV2_AWS_61,CKV2_AWS_62,CKV_AWS_136,CKV_AWS_339'
       - id: terraform_tfsec
         args:
           - '--args=-e aws-s3-specify-public-access-block,aws-cloudwatch-log-group-customer-key,aws-s3-enable-bucket-logging,aws-s3-enable-versioning,aws-s3-no-public-buckets,aws-ec2-require-vpc-flow-logs-for-all-vpcs,aws-s3-encryption-customer-key,aws-ec2-no-public-egress-sgr,aws-iam-no-policy-wildcards,aws-s3-block-public-acls,aws-s3-block-public-policy,aws-s3-enable-bucket-encryption,aws-s3-ignore-public-acls,aws-ec2-no-public-ingress-sgr,aws-ecr-repository-customer-key,aws-ecr-enable-image-scans,aws-eks-no-public-cluster-access,aws-eks-no-public-cluster-access-to-cidr'

--- a/submodules/eks/cluster.tf
+++ b/submodules/eks/cluster.tf
@@ -68,7 +68,8 @@ resource "aws_security_group_rule" "eks_cluster" {
 }
 
 resource "aws_cloudwatch_log_group" "eks_cluster" {
-  name = "/aws/eks/${local.eks_cluster_name}/cluster"
+  name              = "/aws/eks/${local.eks_cluster_name}/cluster"
+  retention_in_days = 365
 }
 
 resource "aws_eks_cluster" "this" {


### PR DESCRIPTION
* [ignore CKV_AWS_339: kubernetes version is specified as a variable](https://github.com/dominodatalab/terraform-aws-eks/commit/4c115cd48c2adb84c43d14b38cc475d9c80cc41b)
* [specify a year-long retention on the EKS cluster logs](https://github.com/dominodatalab/terraform-aws-eks/commit/4d3a584bd2228866948565b8b693e9715d80ac7e)