### PR TITLE
enable ENI prefix delegation by default

### DIFF
--- a/submodules/eks/cluster.tf
+++ b/submodules/eks/cluster.tf
@@ -76,6 +76,11 @@ resource "aws_eks_addon" "vpc_cni" {
   cluster_name      = aws_eks_cluster.this.name
   resolve_conflicts = "OVERWRITE"
   addon_name        = "vpc-cni"
+  configuration_values = jsonencode({
+    env = {
+      ENABLE_PREFIX_DELEGATION = "true"
+    }
+  })
 }
 
 resource "aws_eks_addon" "this" {


### PR DESCRIPTION
By default, m5.2xlarge only allows 44 pods per node. A minimal Domino deployment now exceeds 88 pods for 2 m5.2xlarge nodes. With ENI prefix delegation, we're now allowed up to 110 per node. It does, however, sacrifice some number of IPs per subnet per node, so the overall subnet capacity in terms of pods may be slightly decreased if many workloads require a new node.

This change applies cleanly on an upgrade, but the actual pod limit changes will only be applied when the node group is recreated. That may be problematic, since the actual change in VPC CNI settings could be disconnected from the node group change (e.g. on an upgrade). We could potentially tie the two together to ensure the node groups are tainted, but that might also be an issue.

Overall, I'd be ok closing this as an experiment, we can look into better optimizations for minimal deploys.