### PR TITLE
PLAT-6671: Iam boostrap updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         args:
           - '--args=--compact'
           - '--args=--quiet'
-          - '--args=--skip-check CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6,CKV2_AWS_11,CKV2_AWS_12,CKV2_AWS_6,CKV_AWS_109,CKV_AWS_111,CKV_AWS_135,CKV_AWS_144,CKV_AWS_145,CKV_AWS_158,CKV_AWS_18,CKV_AWS_184,CKV_AWS_19,CKV_AWS_21,CKV_AWS_66,CKV_AWS_88,CKV2_GHA_1,CKV_AWS_163,CKV_AWS_39,CKV_AWS_38,CKV2_AWS_61,CKV2_AWS_62,CKV_AWS_136,CKV_AWS_329,CKV_AWS_338,CKV_AWS_339'
+          - '--args=--skip-check CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6,CKV2_AWS_11,CKV2_AWS_12,CKV2_AWS_6,CKV_AWS_109,CKV_AWS_111,CKV_AWS_135,CKV_AWS_144,CKV_AWS_145,CKV_AWS_158,CKV_AWS_18,CKV_AWS_184,CKV_AWS_19,CKV_AWS_21,CKV_AWS_66,CKV_AWS_88,CKV2_GHA_1,CKV_AWS_163,CKV_AWS_39,CKV_AWS_38,CKV2_AWS_61,CKV2_AWS_62,CKV_AWS_136,CKV_AWS_329,CKV_AWS_338,CKV_AWS_339,CKV_AWS_341'
       - id: terraform_tfsec
         args:
           - '--args=-e aws-s3-specify-public-access-block,aws-cloudwatch-log-group-customer-key,aws-s3-enable-bucket-logging,aws-s3-enable-versioning,aws-s3-no-public-buckets,aws-ec2-require-vpc-flow-logs-for-all-vpcs,aws-s3-encryption-customer-key,aws-ec2-no-public-egress-sgr,aws-iam-no-policy-wildcards,aws-s3-block-public-acls,aws-s3-block-public-policy,aws-s3-enable-bucket-encryption,aws-s3-ignore-public-acls,aws-ec2-no-public-ingress-sgr,aws-ecr-repository-customer-key,aws-ecr-enable-image-scans,aws-eks-no-public-cluster-access,aws-eks-no-public-cluster-access-to-cidr'

--- a/iam-bootstrap/bootstrap-0.json
+++ b/iam-bootstrap/bootstrap-0.json
@@ -14,6 +14,7 @@
                 "s3:GetBucketLocation",
                 "s3:GetBucketLogging",
                 "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketOwnershipControls",
                 "s3:GetBucketPolicy",
                 "s3:GetBucketPublicAccessBlock",
                 "s3:GetBucketRequestPayment",
@@ -27,6 +28,7 @@
                 "s3:PutAccountPublicAccessBlock",
                 "s3:PutBucketAcl",
                 "s3:PutBucketLogging",
+                "s3:PutBucketOwnershipControls",
                 "s3:PutBucketPolicy",
                 "s3:PutBucketRequestPayment",
                 "s3:PutBucketTagging",
@@ -69,10 +71,6 @@
                 "iam:GetInstanceProfile",
                 "iam:GetPolicy",
                 "iam:GetPolicyVersion",
-                "iam:ListAttachedRolePolicies",
-                "iam:ListInstanceProfilesForRole",
-                "iam:ListPolicyVersions",
-                "iam:ListRolePolicies",
                 "iam:PassRole",
                 "iam:PutRolePolicy",
                 "iam:RemoveRoleFromInstanceProfile",
@@ -92,7 +90,12 @@
             "Effect": "Allow",
             "Action": [
                 "iam:GetRole",
-                "iam:GetRolePolicy"
+                "iam:GetRolePolicy",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListInstanceProfilesForRole",
+                "iam:ListPolicyVersions",
+                "iam:ListRolePolicies",
+                "iam:TagRole"
             ],
             "Resource": "*"
         },
@@ -106,7 +109,9 @@
                 "logs:CreateLogDelivery",
                 "logs:DescribeLogGroups",
                 "logs:ListTagsLogGroup",
-                "logs:ListTagsForResource"
+                "logs:ListTagsForResource",
+                "logs:PutRetentionPolicy",
+                "logs:TagLogGroup"
             ],
             "Resource": "*"
         },
@@ -122,7 +127,8 @@
                 "eks:DescribeUpdate",
                 "eks:ListTagsForResource",
                 "eks:TagResource",
-                "eks:UntagResource"
+                "eks:UntagResource",
+                "eks:UpdateNodegroupVersion"
             ],
             "Resource": "*"
         },

--- a/iam-bootstrap/bootstrap-1.json
+++ b/iam-bootstrap/bootstrap-1.json
@@ -29,6 +29,8 @@
             "Action": [
                 "ec2:ModifyInstanceAttribute",
                 "ec2:MonitorInstances",
+                "ec2:StartInstances",
+                "ec2:StopInstances",
                 "ec2:TerminateInstances"
             ],
             "Resource": "*",
@@ -82,7 +84,21 @@
                 "ec2:ReleaseAddress",
                 "ec2:RevokeSecurityGroupEgress",
                 "ec2:RevokeSecurityGroupIngress",
-                "ec2:RunInstances"
+                "ec2:RunInstances",
+                "ssm:GetParameter"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "ECRUngated",
+            "Effect": "Allow",
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:DescribeRepositories",
+                "ecr:ListTagsForResource",
+                "ecr:TagResource"
             ],
             "Resource": [
                 "*"
@@ -98,8 +114,10 @@
                 "kms:DescribeKey",
                 "kms:EnableKeyRotation",
                 "kms:GenerateDataKey",
+                "kms:GenerateDataKeyWithoutPlaintext",
                 "kms:GetKeyRotationStatus",
                 "kms:GetKeyPolicy",
+                "kms:ListAliases",
                 "kms:ListResourceTags",
                 "kms:PutKeyPolicy",
                 "kms:RetireGrant",
@@ -117,6 +135,7 @@
                 "ec2:DeleteFlowLogs",
                 "ec2:DeleteLaunchTemplate",
                 "ec2:DeleteSecurityGroup",
+                "ecr:DeleteRepository",
                 "eks:DeleteCluster",
                 "eks:DeleteNodegroup",
                 "elasticfilesystem:DeleteAccessPoint",

--- a/iam-bootstrap/bootstrap-1.json
+++ b/iam-bootstrap/bootstrap-1.json
@@ -92,7 +92,7 @@
             ]
         },
         {
-            "Sid": "ECRUngated",
+            "Sid": "ECRGated",
             "Effect": "Allow",
             "Action": [
                 "ecr:CreateRepository",
@@ -101,7 +101,7 @@
                 "ecr:TagResource"
             ],
             "Resource": [
-                "*"
+                "arn:${partition}:ecr:*:*:repository/${deploy_id}/*"
             ]
         },
         {

--- a/submodules/storage/efs_backup_vault.tf
+++ b/submodules/storage/efs_backup_vault.tf
@@ -30,6 +30,7 @@ resource "aws_backup_plan" "efs" {
 }
 
 resource "aws_iam_role" "efs_backup_role" {
+  name  = "${var.deploy_id}-efs-backup"
   count = var.storage.efs.backup_vault.create ? 1 : 0
   assume_role_policy = jsonencode({
     Version = "2012-10-17"


### PR DESCRIPTION
Our iam bootstrap glue in the deployer has been broken. :(

Because of this, a small number of more recent requirements since this was created are missing from this role.

A fix to the deployer side of this is forthcoming, but will wait on PLAT-6617 since that will solve a key problem that comes with fixing it. That problem is that once the iam role is the creator, installs become impossible without adding the role to the kubeconfig—something for which there is a chicken/egg problem that will be solved better by PLAT-6617 than what would be done deployer-side. Also means there's one fewer changes in how this fundamentally works.