### PR TITLE
PLAT-6697 Add support for gov cloud

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         args:
           - '--args=--compact'
           - '--args=--quiet'
-          - '--args=--skip-check CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6,CKV2_AWS_11,CKV2_AWS_12,CKV2_AWS_6,CKV_AWS_109,CKV_AWS_111,CKV_AWS_135,CKV_AWS_144,CKV_AWS_145,CKV_AWS_158,CKV_AWS_18,CKV_AWS_184,CKV_AWS_19,CKV_AWS_21,CKV_AWS_66,CKV_AWS_88,CKV2_GHA_1,CKV_AWS_163,CKV_AWS_39,CKV_AWS_38,CKV2_AWS_61,CKV2_AWS_62,CKV_AWS_136,CKV_AWS_329,CKV_AWS_338,CKV_AWS_339'
+          - '--args=--skip-check CKV_CIRCLECIPIPELINES_2,CKV_CIRCLECIPIPELINES_6,CKV2_AWS_11,CKV2_AWS_12,CKV2_AWS_6,CKV_AWS_109,CKV_AWS_111,CKV_AWS_135,CKV_AWS_144,CKV_AWS_145,CKV_AWS_158,CKV_AWS_18,CKV_AWS_184,CKV_AWS_19,CKV_AWS_21,CKV_AWS_66,CKV_AWS_88,CKV2_GHA_1,CKV_AWS_163,CKV_AWS_39,CKV_AWS_38,CKV2_AWS_61,CKV2_AWS_62,CKV_AWS_136,CKV_AWS_329,CKV_AWS_338,CKV_AWS_339,CKV_AWS_341'
       - id: terraform_tfsec
         args:
           - '--args=-e aws-s3-specify-public-access-block,aws-cloudwatch-log-group-customer-key,aws-s3-enable-bucket-logging,aws-s3-enable-versioning,aws-s3-no-public-buckets,aws-ec2-require-vpc-flow-logs-for-all-vpcs,aws-s3-encryption-customer-key,aws-ec2-no-public-egress-sgr,aws-iam-no-policy-wildcards,aws-s3-block-public-acls,aws-s3-block-public-policy,aws-s3-enable-bucket-encryption,aws-s3-ignore-public-acls,aws-ec2-no-public-ingress-sgr,aws-ecr-repository-customer-key,aws-ecr-enable-image-scans,aws-eks-no-public-cluster-access,aws-eks-no-public-cluster-access-to-cidr'

--- a/iam-bootstrap/variables.tf
+++ b/iam-bootstrap/variables.tf
@@ -13,8 +13,8 @@ variable "region" {
   description = "AWS region for the deployment"
   nullable    = false
   validation {
-    condition     = can(regex("^([a-z]{2}-[a-z]+-[0-9])$", var.region))
-    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2."
+    condition     = can(regex("(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-[0-9]", var.region))
+    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2, us-gov-west-1."
   }
 }
 

--- a/submodules/bastion/variables.tf
+++ b/submodules/bastion/variables.tf
@@ -8,8 +8,8 @@ variable "region" {
   type        = string
   nullable    = false
   validation {
-    condition     = can(regex("^([a-z]{2}-[a-z]+-[0-9])$", var.region))
-    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2."
+    condition     = can(regex("(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-[0-9]", var.region))
+    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2, us-gov-west-1."
   }
 }
 

--- a/submodules/eks/variables.tf
+++ b/submodules/eks/variables.tf
@@ -13,8 +13,8 @@ variable "region" {
   description = "AWS region for the deployment"
   nullable    = false
   validation {
-    condition     = can(regex("^([a-z]{2}-[a-z]+-[0-9])$", var.region))
-    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2."
+    condition     = can(regex("(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-[0-9]", var.region))
+    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2, us-gov-west-1."
   }
 }
 

--- a/submodules/network/variables.tf
+++ b/submodules/network/variables.tf
@@ -13,8 +13,8 @@ variable "region" {
   description = "AWS region for the deployment"
   nullable    = false
   validation {
-    condition     = can(regex("^([a-z]{2}-[a-z]+-[0-9])$", var.region))
-    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2."
+    condition     = can(regex("(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-[0-9]", var.region))
+    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2, us-gov-west-1."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@ variable "region" {
   description = "AWS region for the deployment"
   nullable    = false
   validation {
-    condition     = can(regex("^([a-z]{2}-[a-z]+-[0-9])$", var.region))
-    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2."
+    condition     = can(regex("(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-[0-9]", var.region))
+    error_message = "The provided region must follow the format of AWS region names, e.g., us-west-2, us-gov-west-1."
   }
 }
 


### PR DESCRIPTION
Hot fix to support Gov cloud

```
│   on main.tf line 14, in module "eks_cluster":
│   14:   region           = var.region
│     ├────────────────
│     │ var.region is "us-gov-west-1"
│
│ The provided region must follow the format of AWS region names, e.g., us-west-2.
│
│ This was checked by the validation rule at .terraform/modules/eks_cluster/variables.tf:5,3-13.
```