### PR TITLE
DOM-45710 • Enable access to dev-aws-eks-dataplane

### DIFF
--- a/submodules/eks/iam.tf
+++ b/submodules/eks/iam.tf
@@ -8,6 +8,15 @@ data "aws_iam_policy_document" "eks_cluster" {
       identifiers = ["eks.${local.dns_suffix}"]
     }
   }
+  statement {
+    sid     = "EKSClusterAssumeRole"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.aws_account_id}:root"]
+    }
+  }
 }
 
 resource "aws_iam_role" "eks_cluster" {


### PR DESCRIPTION
[DOM-45710](https://dominodatalab.atlassian.net/browse/DOM-45710)

A dataplane deployed with `dev-aws-eks-dataplane` deployer should be accessible via API, similar to `dev-cdk-eks-dataplane`.

Related PR: https://github.com/cerebrotech/platform-apps/pull/7348