### PR TITLE
DOM-47755 • Dataplane deployment failure

### DIFF
--- a/iam-bootstrap/bootstrap-0.json
+++ b/iam-bootstrap/bootstrap-0.json
@@ -144,7 +144,8 @@
         "route53:GetHostedZone",
         "route53:ListTagsForResource",
         "route53:ChangeResourceRecordSets",
-        "route53:GetChange"
+        "route53:GetChange",
+        "route53:ListResourceRecordSets"
       ],
       "Resource": "*"
     },

--- a/iam-bootstrap/bootstrap-0.json
+++ b/iam-bootstrap/bootstrap-0.json
@@ -142,7 +142,8 @@
       "Action": [
         "route53:ListHostedZones",
         "route53:GetHostedZone",
-        "route53:ListTagsForResource"
+        "route53:ListTagsForResource",
+        "route53:ChangeResourceRecordSets"
       ],
       "Resource": "*"
     },

--- a/iam-bootstrap/bootstrap-0.json
+++ b/iam-bootstrap/bootstrap-0.json
@@ -143,7 +143,8 @@
         "route53:ListHostedZones",
         "route53:GetHostedZone",
         "route53:ListTagsForResource",
-        "route53:ChangeResourceRecordSets"
+        "route53:ChangeResourceRecordSets",
+        "route53:GetChange"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
https://dominodatalab.atlassian.net/browse/DOM-47755

Extension of https://github.com/dominodatalab/terraform-aws-eks/pull/106

The ACM certificate created by the dataplane deployer needs to be validated though Route53.