### PR TITLE
PLAT-6938: Run scripts with bash

### DIFF
--- a/submodules/eks/k8s.tf
+++ b/submodules/eks/k8s.tf
@@ -22,7 +22,7 @@ resource "terraform_data" "run_k8s_pre_setup" {
   ]
 
   provisioner "local-exec" {
-    command     = "./${module.k8s_setup[0].filename} set_k8s_auth set_eniconfig"
+    command     = "bash ./${module.k8s_setup[0].filename} set_k8s_auth set_eniconfig"
     interpreter = ["bash", "-c"]
     working_dir = module.k8s_setup[0].resources_directory
   }
@@ -38,7 +38,7 @@ resource "terraform_data" "calico_setup" {
   ]
 
   provisioner "local-exec" {
-    command     = "./${module.k8s_setup[0].filename} install_calico"
+    command     = "bash ./${module.k8s_setup[0].filename} install_calico"
     interpreter = ["bash", "-c"]
     working_dir = module.k8s_setup[0].resources_directory
   }


### PR DESCRIPTION
Execute scripts using bash not as a command to bash. This avoids issues with file permissions getting lost along the way.