### PR TITLE
PLAT-6790 default tags to asgs

### DIFF
--- a/submodules/eks/README.md
+++ b/submodules/eks/README.md
@@ -57,6 +57,7 @@
 | [aws_ami.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.aws_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.aws_eks_provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_default_tags.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_ec2_instance_type_offerings.nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_instance_type_offerings) | data source |
 | [aws_iam_policy_document.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.custom_eks_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/submodules/eks/node-group.tf
+++ b/submodules/eks/node-group.tf
@@ -27,6 +27,9 @@ data "aws_iam_policy_document" "eks_nodes" {
   }
 }
 
+# default tags for use on the asg's
+data "aws_default_tags" "this" {}
+
 resource "aws_iam_role" "eks_nodes" {
   name               = "${local.eks_cluster_name}-eks-nodes"
   assume_role_policy = data.aws_iam_policy_document.eks_nodes.json
@@ -252,6 +255,13 @@ locals {
         key   = format("k8s.io/cluster-autoscaler/node-template/label/%v", lkey)
         value = lvalue
     }]],
+    [for tkey, tvalue in merge(v.node_group.tags, data.aws_default_tags.this.tags) : [
+      {
+        name  = name
+        key   = tkey
+        value = tvalue
+      }
+    ]],
     [for t in v.node_group.taints : [
       {
         name  = name

--- a/submodules/eks/node-group.tf
+++ b/submodules/eks/node-group.tf
@@ -255,7 +255,7 @@ locals {
         key   = format("k8s.io/cluster-autoscaler/node-template/label/%v", lkey)
         value = lvalue
     }]],
-    [for tkey, tvalue in merge(v.node_group.tags, data.aws_default_tags.this.tags) : [
+    [for tkey, tvalue in data.aws_default_tags.this.tags : [
       {
         name  = name
         key   = tkey


### PR DESCRIPTION
The aws provider default tags do not propagate to the ASG's because they are not created by terraform. However we already tag those ASG's with various things to assist with other k8s aspects of the deployment.  

This just adds those default tags into the ASGs, as well as bringing any custom nodegroup tags down to them as well.  In most instances this will improve the expectation from external auditing/IT orgs that things are tagged consistently.