### PR TITLE
Support UpdateNodegroupConfig in bootstrap IAM, ignore min_size for nodegroup scaling

### DIFF
--- a/iam-bootstrap/bootstrap-0.json
+++ b/iam-bootstrap/bootstrap-0.json
@@ -132,6 +132,7 @@
         "eks:ListTagsForResource",
         "eks:TagResource",
         "eks:UntagResource",
+        "eks:UpdateNodegroupConfig",
         "eks:UpdateNodegroupVersion"
       ],
       "Resource": "*"

--- a/submodules/eks/node-group.tf
+++ b/submodules/eks/node-group.tf
@@ -224,6 +224,7 @@ resource "aws_eks_node_group" "node_groups" {
   lifecycle {
     ignore_changes = [
       scaling_config[0].desired_size,
+      scaling_config[0].min_size,
     ]
   }
 


### PR DESCRIPTION
* eks:UpdateNodegroupConfig is used to change nodegroup configuration in-place
* If nodegroup `min_size` is changed, we don't particularly care and can ignore it