### PR TITLE
remove coupling between eks and network modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,6 @@ module "eks" {
   bastion_info       = local.bastion_info
 
   depends_on = [
-    module.network,
     aws_iam_role.create_eks_role,
     aws_iam_policy.create_eks_role,
     aws_iam_role_policy_attachment.create_eks_role


### PR DESCRIPTION
Because network also depends on storage, any KMS key change will cause the whole module data sources to refresh even though nothing has changed.

Original change was in https://github.com/dominodatalab/terraform-aws-eks/pull/5, but the use-case no longer exists.