### PR TITLE
Explicitly set the default EKS addon version

### DIFF
--- a/submodules/eks/README.md
+++ b/submodules/eks/README.md
@@ -58,6 +58,7 @@
 | [aws_caller_identity.aws_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.aws_eks_provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ec2_instance_type_offerings.nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ec2_instance_type_offerings) | data source |
+| [aws_eks_addon_version.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon_version) | data source |
 | [aws_iam_policy_document.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.custom_eks_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/submodules/eks/cluster.tf
+++ b/submodules/eks/cluster.tf
@@ -85,11 +85,18 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
 }
 
 
+data "aws_eks_addon_version" "default" {
+  for_each           = toset(concat(["vpc-cni"], var.eks.cluster_addons))
+  addon_name         = each.key
+  kubernetes_version = aws_eks_cluster.this.version
+}
+
 resource "aws_eks_addon" "vpc_cni" {
   cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = "vpc-cni"
+  addon_version               = data.aws_eks_addon_version.default["vpc-cni"].version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
-  addon_name                  = "vpc-cni"
   configuration_values = jsonencode({
     env = merge(
       {},
@@ -101,9 +108,10 @@ resource "aws_eks_addon" "vpc_cni" {
 resource "aws_eks_addon" "this" {
   for_each                    = toset(var.eks.cluster_addons)
   cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = each.key
+  addon_version               = data.aws_eks_addon_version.default[each.key].version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
-  addon_name                  = each.key
 
   depends_on = [
     aws_eks_node_group.node_groups,


### PR DESCRIPTION
[DOM-49709](https://dominodatalab.atlassian.net/browse/DOM-49709)

Upon initial install  `aws_eks_addon` computes the default version, but these can be deprecated and the same `aws_eks_addon` will fail to update if the version is not updated as well.
Given the following example where there were updates to the resource definition, and the `v1.11.4-eksbuild.1` had been deprecated:
```
# module.eks.module.eks.aws_eks_addon.vpc_cni:
resource "aws_eks_addon" "vpc_cni" {
    addon_name        = "vpc-cni"
    addon_version     = "v1.11.4-eksbuild.1"
   truncated for brevity...
```
Upon update `resolve_conflicts` fields update(Notice the version is not being updated)

```
 # module.eks.module.eks.aws_eks_addon.vpc_cni will be updated in-place
 ~ resource "aws_eks_addon" "vpc_cni" {
     + configuration_values        = jsonencode(
           {
             + env = {}
           }
       )
       id                          = "se-test26353:vpc-cni"
     - resolve_conflicts           = "OVERWRITE" -> null
     + resolve_conflicts_on_create = "OVERWRITE"
     + resolve_conflicts_on_update = "OVERWRITE"
       tags                        = {}
       # (7 unchanged attributes hidden)
   }
```
Fails with 
```
Error: updating EKS Add-On (se-test26353:vpc-cni): InvalidParameterException: Addon version specified is not supported
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "b6c5660a-5e28-4995-acf6-77038c15fe93"
  },
  AddonName: "se-test26353",
  ClusterName: "vpc-cni",
  Message_: "Addon version specified is not supported"
}
```
To fix this behavior we leverage the [eks_addon_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon_version.html) data source to always compute the default version. 

:warning: **Note:**  that the `eks_addon` will somewhat follow the same behavior as the `aws_eks_node_group`, that is, spaced plans will compute differences if the versions are updated.
