### PR TITLE
Adds the aws-service-role resource to CreateServiceLinkedRole action

### DIFF
--- a/iam-bootstrap/bootstrap-0.json
+++ b/iam-bootstrap/bootstrap-0.json
@@ -83,7 +83,8 @@
         "arn:${partition}:iam::${account_id}:role/${deploy_id}-*",
         "arn:${partition}:iam::${account_id}:instance-profile/${deploy_id}-*",
         "arn:${partition}:iam::${account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
-        "arn:${partition}:iam::${account_id}:oidc-provider/oidc.eks*"
+        "arn:${partition}:iam::${account_id}:oidc-provider/oidc.eks*",
+        "arn:${partition}:iam::${account_id}:role/aws-service-role/*"
       ]
     },
     {


### PR DESCRIPTION
The `iam_bootstrap` role is missing resource `"arn:${data.aws_partition.current.partition}:iam::${local.aws_account_id}:role/aws-service-role/*"` for action `iam:CreateServiceLinkedRole"` causes the following on a fresh account.

```
Error: creating EKS Node Group (cloud-dogfood:cloud-dogfood-compute-1): InvalidRequestException: Failed to create service linked role: AWSServiceRoleForAmazonEKSNodegroup due to missing permissions for 'iam:CreateServiceLinkedRole'
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "6c842182-9eca-4c5f-9c82-a4681b7cc680"
  },
  Message_: "Failed to create service linked role: AWSServiceRoleForAmazonEKSNodegroup due to missing permissions for 'iam:CreateServiceLinkedRole'"
}
```