### PR TITLE
PLAT-6790 Add instance_tags to the asg's themselves as well

### DIFF
--- a/modules/nodes/nodes.tf
+++ b/modules/nodes/nodes.tf
@@ -144,6 +144,13 @@ locals {
         key   = format("k8s.io/cluster-autoscaler/node-template/label/%v", lkey)
         value = lvalue
     }]],
+    [for tkey, tvalue in v.node_group.instance_tags : [
+      {
+        name  = name
+        key   = tkey
+        value = tvalue
+      }
+    ]],
     [for t in v.node_group.taints : [
       {
         name  = name


### PR DESCRIPTION
Because ASG's are not created by the terraform the default tags are not propagated.  Apparently this was a duplicate issue with instance tags somewhere in the past, because the functionality to bring the default tags down to the nodegroups already exists.  

All this commit does is include this same variable set so that the asg's get tagged as well.