### PR TITLE
Remove version pin for aws provider

### DIFF
--- a/modules/infra/README.md
+++ b/modules/infra/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.4.0 |
@@ -15,7 +15,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9.1 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.4.0 |
 

--- a/modules/infra/submodules/storage/README.md
+++ b/modules/infra/submodules/storage/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | < 5.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
 
 ## Modules
 

--- a/modules/infra/submodules/storage/versions.tf
+++ b/modules/infra/submodules/storage/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.17"
+      version = "~> 5"
     }
   }
 }

--- a/modules/infra/versions.tf
+++ b/modules/infra/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "< 5.17"
+      version = "~> 5"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
Registry released `v5.18.1` 

```
Initializing provider plugins...
- Finding latest version of hashicorp/aws...
- Installing hashicorp/aws v5.18.1...
- Installed hashicorp/aws v5.18.1 (signed by HashiCorp
```