### PR TITLE
[DOM-48979] -- add vault agent webhook port

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -89,6 +89,14 @@ locals {
       type                          = "ingress"
       source_cluster_security_group = true
     }
+    ingress_cluster_8080 = {
+      description                   = "Cluster API to Vault Agent webhook"
+      protocol                      = "tcp"
+      from_port                     = 8080
+      to_port                       = 8080
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
     ingress_cluster_443 = {
       description                   = "Cluster API to node groups 443"
       protocol                      = "tcp"


### PR DESCRIPTION
Need to add a special rule to allow the k8s apiserver to connect to the vault agent injector webhook

tested against a dev-v2 that it does what we want!