### PR TITLE
convert monitoring bucket away from ACLs

### DIFF
--- a/modules/infra/submodules/storage/README.md
+++ b/modules/infra/submodules/storage/README.md
@@ -13,6 +13,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -39,10 +40,8 @@ No modules.
 | [aws_s3_bucket.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_acl.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_lifecycle_configuration.costs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.buckets_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
-| [aws_s3_bucket_ownership_controls.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.buckets_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.block_public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_request_payment_configuration.buckets_payer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_request_payment_configuration) | resource |
@@ -50,7 +49,7 @@ No modules.
 | [aws_s3_bucket_server_side_encryption_configuration.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.buckets_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_security_group.efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_canonical_user_id.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) | data source |
+| [terraform_data.set_monitoring_private_acl](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_elb_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy.aws_backup_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/modules/infra/submodules/storage/main.tf
+++ b/modules/infra/submodules/storage/main.tf
@@ -1,4 +1,3 @@
-data "aws_canonical_user_id" "current" {}
 data "aws_elb_service_account" "this" {}
 data "aws_partition" "current" {}
 

--- a/modules/infra/submodules/storage/s3.tf
+++ b/modules/infra/submodules/storage/s3.tf
@@ -335,14 +335,8 @@ resource "terraform_data" "set_monitoring_private_acl" {
       update_bucket() {
         ownership=$(aws s3api get-bucket-ownership-controls --bucket $bucket --output text --query "OwnershipControls.Rules[0]")
         if [[ "$ownership" == "BucketOwnerPreferred" ]] || [[ -z "$ownership" ]]; then
-          if ! aws s3api put-bucket-acl --bucket $bucket --acl private; then
-            return 1
-          fi
-
-
-          if ! aws s3api put-bucket-ownership-controls --bucket $bucket --ownership-controls "Rules=[{ObjectOwnership=BucketOwnerEnforced}]"; then
-            return 1
-          fi
+          aws s3api put-bucket-acl --bucket $bucket --acl private || return 1
+          aws s3api put-bucket-ownership-controls --bucket $bucket --ownership-controls "Rules=[{ObjectOwnership=BucketOwnerEnforced}]" || return 1
         fi
 
         return 0

--- a/modules/infra/submodules/storage/s3.tf
+++ b/modules/infra/submodules/storage/s3.tf
@@ -218,9 +218,8 @@ resource "aws_s3_bucket" "monitoring" {
 
 data "aws_iam_policy_document" "monitoring" {
   statement {
-
+    sid    = "DenyInsecureTransport"
     effect = "Deny"
-
     resources = [
       "arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.monitoring.bucket}",
       "arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.monitoring.bucket}/*",
@@ -241,7 +240,7 @@ data "aws_iam_policy_document" "monitoring" {
   }
 
   statement {
-    sid       = ""
+    sid       = "ELBLogDelivery"
     effect    = "Allow"
     resources = ["arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.monitoring.bucket}/*"]
 
@@ -289,6 +288,30 @@ data "aws_iam_policy_document" "monitoring" {
       identifiers = ["delivery.logs.amazonaws.com"]
     }
   }
+
+  statement {
+    sid       = "AWSAccessLogDeliveryWrite"
+    effect    = "Allow"
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.monitoring.bucket}/*"]
+    actions   = ["s3:PutObject"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid       = "AWSAccessLogDeliveryAclCheck"
+    effect    = "Allow"
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.monitoring.bucket}"]
+    actions   = ["s3:GetBucketAcl"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "monitoring" {
@@ -301,55 +324,51 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "monitoring" {
   }
 }
 
-resource "aws_s3_bucket_ownership_controls" "monitoring" {
-  bucket = aws_s3_bucket.monitoring.id
-  rule {
-    object_ownership = "BucketOwnerPreferred"
+resource "terraform_data" "set_monitoring_private_acl" {
+  provisioner "local-exec" {
+    command     = <<-EOF
+      set -x -o pipefail
+
+      sleep_duration=10
+      bucket="${aws_s3_bucket.monitoring.bucket}"
+
+      update_bucket() {
+        ownership=$(aws s3api get-bucket-ownership-controls --bucket $bucket --output text --query "OwnershipControls.Rules[0]")
+        if [[ "$ownership" == "BucketOwnerPreferred" ]] || [[ -z "$ownership" ]]; then
+          if ! aws s3api put-bucket-acl --bucket $bucket --acl private; then
+            return 1
+          fi
+
+
+          if ! aws s3api put-bucket-ownership-controls --bucket $bucket --ownership-controls "Rules=[{ObjectOwnership=BucketOwnerEnforced}]"; then
+            return 1
+          fi
+        fi
+
+        return 0
+      }
+
+      for _ in {1..3}; do
+        if update_bucket; then
+          exit 0
+        fi
+
+        sleep "$sleep_duration"
+      done
+
+      echo "Could not set bucket ownership for $bucket"
+      exit 1
+    EOF
+    interpreter = ["bash", "-c"]
   }
-}
 
-resource "aws_s3_bucket_acl" "monitoring" {
-  depends_on = [aws_s3_bucket_ownership_controls.monitoring]
-
-  bucket = aws_s3_bucket.monitoring.id
-
-  access_control_policy {
-
-    owner {
-      id = data.aws_canonical_user_id.current.id
-    }
-
-    grant {
-      grantee {
-        type = "CanonicalUser"
-        id   = data.aws_canonical_user_id.current.id
-      }
-      permission = "FULL_CONTROL"
-    }
-
-    grant {
-      grantee {
-        type = "Group"
-        uri  = "http://acs.amazonaws.com/groups/s3/LogDelivery"
-      }
-      permission = "WRITE"
-    }
-
-    grant {
-      grantee {
-        type = "Group"
-        uri  = "http://acs.amazonaws.com/groups/s3/LogDelivery"
-      }
-      permission = "READ_ACP"
-    }
-  }
+  depends_on = [aws_s3_bucket.monitoring]
 }
 
 resource "aws_s3_bucket" "registry" {
   bucket              = "${var.deploy_id}-registry"
   force_destroy       = var.storage.s3.force_destroy_on_deletion
   object_lock_enabled = false
-
 }
 
 data "aws_iam_policy_document" "registry" {


### PR DESCRIPTION
This is two changes in one:
1. We see (very) occasional timeouts when provisioning new infra: `(xyz-monitoring) ACL: operation error S3: PutBucketAcl, https response error StatusCode: 400`. My hunch is some sort of propagation delay for the ownership control setting.
2. We don't really need to use ACLs and the preference going forward is to just use policies. However, this is complicated because of our existing infrastructure. In order to set the policy to `BucketOwnerEnforced` the existing grants need to be removed. AFAICT for new installs, there's no way to automatically bypass the grant removal.