### PR TITLE
* Bump EKS node group update timeout to 2h

### DIFF
--- a/modules/nodes/nodes.tf
+++ b/modules/nodes/nodes.tf
@@ -119,6 +119,10 @@ resource "aws_eks_node_group" "node_groups" {
     ]
   }
 
+  timeouts {
+    update = "2h"
+  }
+
   update_config {
     max_unavailable = 1
   }


### PR DESCRIPTION
We've encountered an issue during the creation of EKS clusters where the operation times out after 60 minutes, throwing an error related to an `ExpiredTokenException.` The root cause seems to be related to the update timeout during the cluster creation process.

This issue has been causing intermittent disruptions, and after investigation, we are proposing an update to the timeout settings related to EKS cluster node group creation