### PR TITLE
[DOM-52327] Adding boostrap permissions

### DIFF
--- a/modules/iam-bootstrap/bootstrap-1.json
+++ b/modules/iam-bootstrap/bootstrap-1.json
@@ -239,9 +239,17 @@
         "cur:PutReportDefinition",
         "cur:DescribeReportDefinitions",
         "cur:DeleteReportDefinition",
+        "signer:*",
         "lambda:CreateCodeSigningConfig",
         "lambda:UpdateCodeSigningConfig",
-        "lambda:GetCodeSigningConfig"
+        "lambda:GetCodeSigningConfig",
+        "lambda:CreateFunction",
+        "lambda:TagResource",
+        "lambda:GetFunction",
+        "lambda:ListVersionsByFunction",
+        "lambda:GetFunctionCodeSigningConfig",
+        "lambda:DeleteFunction",
+        "lambda:PutFunctionConcurrency"
       ],
       "Resource": "*"
     }

--- a/modules/iam-bootstrap/bootstrap-1.json
+++ b/modules/iam-bootstrap/bootstrap-1.json
@@ -249,7 +249,12 @@
         "lambda:ListVersionsByFunction",
         "lambda:GetFunctionCodeSigningConfig",
         "lambda:DeleteFunction",
-        "lambda:PutFunctionConcurrency"
+        "lambda:PutFunctionConcurrency",
+        "lambda:AddPermission",
+        "lambda:RemovePermission",
+        "lambda:UpdateFunctionConfiguration",
+        "lambda:GetPolicy",
+        "s3:*"
       ],
       "Resource": "*"
     }

--- a/modules/iam-bootstrap/bootstrap-1.json
+++ b/modules/iam-bootstrap/bootstrap-1.json
@@ -104,7 +104,9 @@
         "ec2:RunInstances",
         "ssm:GetParameter"
       ],
-      "Resource": ["*"]
+      "Resource": [
+        "*"
+      ]
     },
     {
       "Sid": "ACMUngated",
@@ -117,7 +119,9 @@
         "acm:ListCertificates",
         "acm:DeleteCertificate"
       ],
-      "Resource": ["*"]
+      "Resource": [
+        "*"
+      ]
     },
     {
       "Sid": "ECRGated",
@@ -129,7 +133,9 @@
         "ecr:TagResource",
         "ecr:UntagResource"
       ],
-      "Resource": ["arn:${partition}:ecr:*:*:repository/${deploy_id}/*"]
+      "Resource": [
+        "arn:${partition}:ecr:*:*:repository/${deploy_id}/*"
+      ]
     },
     {
       "Sid": "KMSUngated",
@@ -213,6 +219,10 @@
         "glue:GetTags",
         "glue:CreateCrawler",
         "glue:CreateTable",
+        "glue:GetTable",
+        "glue:DeleteTable",
+        "glue:GetCrawler",
+        "glue:DeleteCrawler",
         "athena:CreateWorkGroup",
         "athena:GetWorkGroup",
         "athena:DeleteWorkGroup",
@@ -220,6 +230,7 @@
         "athena:ListTagsForResource",
         "iam:CreateRole",
         "iam:PutRolePolicy",
+        "iam:PassRole",
         "sqs:createqueue",
         "sqs:deletequeue",
         "sqs:tagqueue",
@@ -227,7 +238,10 @@
         "sqs:listqueuetags",
         "cur:PutReportDefinition",
         "cur:DescribeReportDefinitions",
-        "cur:DeleteReportDefinition"
+        "cur:DeleteReportDefinition",
+        "lambda:CreateCodeSigningConfig",
+        "lambda:UpdateCodeSigningConfig",
+        "lambda:GetCodeSigningConfig"
       ],
       "Resource": "*"
     }

--- a/modules/iam-bootstrap/bootstrap-1.json
+++ b/modules/iam-bootstrap/bootstrap-1.json
@@ -199,6 +199,37 @@
         "elasticloadbalancing:DescribeTags"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "DominoCurUngated",
+      "Effect": "Allow",
+      "Action": [
+        "glue:CreateDatabase",
+        "glue:GetDatabase",
+        "glue:DeleteDatabase",
+        "glue:CreateSecurityConfiguration",
+        "glue:GetSecurityConfiguration",
+        "glue:DeleteSecurityConfiguration",
+        "glue:GetTags",
+        "glue:CreateCrawler",
+        "glue:CreateTable",
+        "athena:CreateWorkGroup",
+        "athena:GetWorkGroup",
+        "athena:DeleteWorkGroup",
+        "athena:TagResource",
+        "athena:ListTagsForResource",
+        "iam:CreateRole",
+        "iam:PutRolePolicy",
+        "sqs:createqueue",
+        "sqs:deletequeue",
+        "sqs:tagqueue",
+        "sqs:getqueueattributes",
+        "sqs:listqueuetags",
+        "cur:PutReportDefinition",
+        "cur:DescribeReportDefinitions",
+        "cur:DeleteReportDefinition"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Adds more bootstrap permissions required with the changes introduced in https://github.com/dominodatalab/terraform-aws-eks/pull/163 to create the new resources (from CUR, Glue, Athena, ...)

## TODO
- [ ] Narrow some permissions further, especially the `<service>:*` ones
- [ ] Use a gated role instead of ungated (if possible)
- [ ] Split the role into a few separate roles (if necessary)