### PR TITLE
RE-1733 add SG rule for NewRelic metadata injector webhook

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -177,6 +177,14 @@ locals {
       type        = "egress"
       self        = true
     }
+    ingress_cluster_8443 = {
+      description                   = "Cluster API to NewRelic webhook"
+      protocol                      = "tcp"
+      from_port                     = 8443
+      to_port                       = 8443
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
     }, var.privatelink.enabled ? {
     private_link = {
       description              = "NLB from private link to node ports"


### PR DESCRIPTION
Per RE-1649 we need an inbound SG rule. There needs to be a firewall rule open between the eks control plane and the deployment nodes for this to work.

This work is being tracked in RE-1733