### PR TITLE
PLAT-7892 Adds a sh to handle multiple minors jump

### DIFF
--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -56,7 +56,6 @@
 | [terraform_data.upgrade_vpc_cni](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_caller_identity.aws_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.aws_eks_provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon) | data source |
 | [aws_eks_addon_version.default_vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon_version) | data source |
 | [aws_iam_policy_document.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.custom_eks_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -7,6 +7,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.2.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
@@ -16,6 +17,7 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 | <a name="provider_aws.eks"></a> [aws.eks](#provider\_aws.eks) | ~> 5.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 2.2.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.1.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
@@ -48,10 +50,13 @@
 | [aws_security_group_rule.efs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [local_file.upgrade_vpc_cni](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.kubeconfig](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [terraform_data.run_k8s_pre_setup](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.upgrade_vpc_cni](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_caller_identity.aws_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.aws_eks_provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon) | data source |
 | [aws_eks_addon_version.default_vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_addon_version) | data source |
 | [aws_iam_policy_document.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.custom_eks_node_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/modules/eks/cluster.tf
+++ b/modules/eks/cluster.tf
@@ -85,26 +85,6 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
   url             = data.tls_certificate.cluster_tls_certificate.url
 }
 
-
-data "aws_eks_addon_version" "default_vpc_cni" {
-  addon_name         = "vpc-cni"
-  kubernetes_version = aws_eks_cluster.this.version
-}
-
-resource "aws_eks_addon" "vpc_cni" {
-  cluster_name                = aws_eks_cluster.this.name
-  addon_name                  = "vpc-cni"
-  addon_version               = data.aws_eks_addon_version.default_vpc_cni.version
-  resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "OVERWRITE"
-  configuration_values = jsonencode({
-    env = {
-      ENABLE_PREFIX_DELEGATION = tostring(try(var.eks.vpc_cni.prefix_delegation, false))
-      ANNOTATE_POD_IP          = tostring(try(var.eks.vpc_cni.annotate_pod_ip, true))
-    }
-  })
-}
-
 resource "null_resource" "kubeconfig" {
   provisioner "local-exec" {
     when    = create

--- a/modules/eks/templates/upgrade-addon.sh.tftpl
+++ b/modules/eks/templates/upgrade-addon.sh.tftpl
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+eks_cluster_name=${eks_cluster_name}
+k8s_version=${k8s_version}
+aws_region=${aws_region}
+configuration_values='${configuration_values}'
+addon_name=${addon_name}
+addon_version=${addon_version}
+
+YELLOW='\033[1;33m'
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+eks="aws eks --region $aws_region"
+
+log_info() {
+  printf "$${YELLOW}[INFO] %s$${NC}\n" "$1"
+}
+
+log_error() {
+  printf "$${RED}[ERROR] %s$${NC}\n" "$1"
+}
+
+log_success() {
+  printf "$${GREEN}[SUCCESS] %s$${NC}\n" "$1"
+}
+
+is_addon_installed() {
+  local -a installed_addons
+  mapfile -t installed_addons <<<$($eks list-addons --cluster-name "$eks_cluster_name" --query 'addons' --output json | jq '.[]')
+  for addon in "$${installed_addons[@]}"; do
+    if [ "$addon" == "$addon_name" ]; then
+      log_info "$addon_name is installed."
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+wait_for_update() {
+  local update_version="$1"
+
+  local sleep_duration=10
+
+  for _ in {1..60}; do
+
+    local current_version=$($eks describe-addon --cluster-name "$eks_cluster_name" --addon-name "$addon_name" --query 'addon.addonVersion' --output text)
+    local status=$($eks describe-addon --cluster-name "$eks_cluster_name" --addon-name "$addon_name" --query 'addon.status' --output text)
+
+    log_info "current_version: $current_version | status: $status"
+
+    if [ "$current_version" == "$update_version" ] && [ "$status" == "ACTIVE" ]; then
+      log_success "$addon_name addon upgrade to version: $update_version was successful."
+      return 0
+    fi
+
+    sleep "$sleep_duration"
+  done
+
+  log_error "Timeout reached(10m). Upgrade to version $update_version Failed. Exiting..."
+  return 1
+}
+
+upgrade_addon() {
+  local current_version=$($eks describe-addon --cluster-name "$eks_cluster_name" --addon-name "$addon_name" --query 'addon.addonVersion' --output text)
+
+  local current_major_version=$(echo $current_version | cut -d'.' -f1)
+  local current_minor_version=$(echo $current_version | cut -d'.' -f2)
+
+  local major_version=$(echo $addon_version | cut -d'.' -f1)
+  local minor_version=$(echo $addon_version | cut -d'.' -f2)
+
+  local current_major_minor_version="$(echo $current_version | cut -d'.' -f1,2)"
+  local major_minor_version="$(echo $addon_version | cut -d'.' -f1,2)"
+
+  log_info "current_version: $current_version | addon_version: $addon_version"
+
+  if [ "$current_version" == "$addon_version" ]; then
+    log_success "$addon_name addon version: $current_version is up to date."
+    return 0
+  fi
+
+  if [ "$current_major_minor_version" == "$major_minor_version" ]; then
+    log_success "major.minor versions are the same, Terraform can handle the upgrade."
+    return 0
+  fi
+
+  if [ "$current_major_version" == "$major_version" ] && [ $((minor_version - current_minor_version)) -eq 1 ]; then
+    log_success "major versions are the same, and minor version differs by 1, Terraform can handle the upgrade."
+    return 0
+  fi
+
+  local versions=$($eks describe-addon-versions --kubernetes-version "$k8s_version" --addon-name "$addon_name" --query 'addons[0].addonVersions[].addonVersion' --output text)
+
+  local -a upgrade_versions
+  mapfile -t upgrade_versions < <(echo "$versions" | grep -o 'v1\.[0-9]*\.[0-9]*-eksbuild\.[0-9]*' | sort -V | awk -F '.' -v start="$current_version" -v end="$addon_version" '
+        $0 >= start && $0 <= end {
+            minor_version = $1 "." $2
+            latest_minor[minor_version] = $0
+        }
+        END {
+            for (version in latest_minor) {
+                print latest_minor[version]
+            }
+        }' | grep -v -E "$current_major_minor_version|$major_minor_version")
+
+  if [ -z "$${upgrade_versions[*]}" ]; then
+    log_error "There are no versions to upgrade, but were expected... Exiting."
+    return 1
+  fi
+
+  for version in "$${upgrade_versions[@]}"; do
+    log_info "Upgrading $addon_name to: $version"
+
+    $eks update-addon \
+      --cluster-name "$eks_cluster_name" \
+      --addon-name "$addon_name" \
+      --addon-version "$version" \
+      --resolve-conflicts "OVERWRITE" \
+      --configuration-values $configuration_values
+
+    wait_for_update "$version" || return 1
+  done
+
+  log_info "Terraform(module.eks.aws_eks_addon.vpc_cni) will perform the final version upgrade to: $addon_version"
+
+}
+
+if is_addon_installed; then
+  log_success "$addon_name is not installed.Terraform can handle the installation."
+else
+  upgrade_addon || exit 1
+fi

--- a/modules/eks/versions.tf
+++ b/modules/eks/versions.tf
@@ -15,6 +15,10 @@ terraform {
       version = ">= 4.0"
 
     }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.2.0"
+    }
   }
 }
 

--- a/modules/eks/vpc-cni.tf
+++ b/modules/eks/vpc-cni.tf
@@ -5,11 +5,6 @@ data "aws_eks_addon_version" "default_vpc_cni" {
   most_recent        = true
 }
 
-data "aws_eks_addon" "vpc_cni" {
-  addon_name   = "vpc-cni"
-  cluster_name = aws_eks_cluster.this.name
-}
-
 locals {
   vpc_cni_config_values = jsonencode({
     env = {
@@ -45,7 +40,6 @@ resource "terraform_data" "upgrade_vpc_cni" {
 
   triggers_replace = [
     local_file.upgrade_vpc_cni.content_md5,
-    data.aws_eks_addon.vpc_cni.addon_version,
     aws_eks_cluster.this.id
   ]
   depends_on = [local_file.upgrade_vpc_cni, aws_eks_cluster.this]

--- a/modules/eks/vpc-cni.tf
+++ b/modules/eks/vpc-cni.tf
@@ -1,0 +1,62 @@
+
+data "aws_eks_addon_version" "default_vpc_cni" {
+  addon_name         = "vpc-cni"
+  kubernetes_version = aws_eks_cluster.this.version
+  most_recent        = true
+}
+
+data "aws_eks_addon" "vpc_cni" {
+  addon_name   = "vpc-cni"
+  cluster_name = aws_eks_cluster.this.name
+}
+
+locals {
+  vpc_cni_config_values = jsonencode({
+    env = {
+      ENABLE_PREFIX_DELEGATION = tostring(try(var.eks.vpc_cni.prefix_delegation, false))
+      ANNOTATE_POD_IP          = tostring(try(var.eks.vpc_cni.annotate_pod_ip, true))
+    }
+  })
+
+  upgrade_addon_tpl = "${path.module}/templates/upgrade-addon.sh.tftpl"
+  upgrade_addon_sh  = "${path.cwd}/upgrade-addon.sh"
+}
+
+resource "local_file" "upgrade_vpc_cni" {
+  content = templatefile(local.upgrade_addon_tpl, {
+    eks_cluster_name     = aws_eks_cluster.this.name
+    k8s_version          = aws_eks_cluster.this.version
+    aws_region           = var.region
+    configuration_values = local.vpc_cni_config_values
+    addon_name           = "vpc-cni"
+    addon_version        = data.aws_eks_addon_version.default_vpc_cni.version
+  })
+  filename             = local.upgrade_addon_sh
+  directory_permission = "0777"
+  file_permission      = "0744"
+}
+
+resource "terraform_data" "upgrade_vpc_cni" {
+  provisioner "local-exec" {
+    command     = "bash ./${basename(local.upgrade_addon_sh)}"
+    interpreter = ["bash", "-c"]
+    working_dir = dirname(local_file.upgrade_vpc_cni.filename)
+  }
+
+  triggers_replace = [
+    local_file.upgrade_vpc_cni.content_md5,
+    data.aws_eks_addon.vpc_cni.addon_version,
+    aws_eks_cluster.this.id
+  ]
+  depends_on = [local_file.upgrade_vpc_cni, aws_eks_cluster.this]
+}
+
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name                = aws_eks_cluster.this.name
+  addon_name                  = "vpc-cni"
+  addon_version               = data.aws_eks_addon_version.default_vpc_cni.version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  configuration_values        = local.vpc_cni_config_values
+  depends_on                  = [terraform_data.upgrade_vpc_cni]
+}


### PR DESCRIPTION
[PLAT-7892](https://dominodatalab.atlassian.net/browse/PLAT-7892)

Adds script to handle the eks `vpc-cni` addon upgrade in the case of more than 1 minor version jump.