### PR TITLE
PLAT-7948: Add DescribeRecoveryPoint to bootstrap

### DIFF
--- a/modules/iam-bootstrap/bootstrap-1.json
+++ b/modules/iam-bootstrap/bootstrap-1.json
@@ -13,7 +13,8 @@
         "backup:ListTags",
         "backup:TagResource",
         "backup:UntagResource",
-        "backup:DeleteRecoveryPoint"
+        "backup:DeleteRecoveryPoint",
+        "backup:DescribeRecoveryPoint"
       ],
       "Resource": [
         "arn:${partition}:backup:*:${account_id}:backup-vault:${deploy_id}-efs",


### PR DESCRIPTION
The EFS backup force destroy feature of Terraform is silently failing calls to `DescribeRecoveryPoint` when used under the IAM bootstrap role, which makes it appear to fail as if the force destroy option doesn't work. In reality, it is trying to destroy the recovery points, but it can't track whether or not the destruction happened. It just doesn't appear to error when DescribeRecoveryPoint fails, and instead it just moves on and tries to delete the backup vault before it's ready.

This adds the missing permission to iam bootstrap.