### PR TITLE
[DOM-55148] Use KMS as default in Flyte s3 buckets

### DIFF
--- a/modules/flyte/README.md
+++ b/modules/flyte/README.md
@@ -50,6 +50,7 @@ No modules.
 | <a name="input_force_destroy_on_deletion"></a> [force\_destroy\_on\_deletion](#input\_force\_destroy\_on\_deletion) | Whether to force destroy flyte s3 buckets on deletion | `bool` | `true` | no |
 | <a name="input_platform_namespace"></a> [platform\_namespace](#input\_platform\_namespace) | Name of Domino platform namespace for this deploy | `string` | n/a | yes |
 | <a name="input_serviceaccount_names"></a> [serviceaccount\_names](#input\_serviceaccount\_names) | Service account names for Flyte | <pre>object({<br>    datacatalog    = optional(string, "datacatalog")<br>    flyteadmin     = optional(string, "flyteadmin")<br>    flytepropeller = optional(string, "flytepropeller")<br>  })</pre> | `{}` | no |
+| <a name="input_kms_info"></a> [kms\_info](#input\_kms\_info) | key\_id  = KMS key id.<br>    key\_arn = KMS key arn.<br>    enabled = KMS key is enabled | <pre>object({<br>    key_id  = string<br>    key_arn = string<br>    enabled = bool<br>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/flyte/s3.tf
+++ b/modules/flyte/s3.tf
@@ -1,3 +1,8 @@
+locals {
+  s3_server_side_encryption = var.kms_info.enabled ? "aws:kms" : "AES256"
+  kms_key_arn               = var.kms_info.enabled ? var.kms_info.key_arn : null
+}
+
 resource "aws_s3_bucket" "flyte_metadata" {
   bucket              = "${local.deploy_id}-flyte-metadata"
   force_destroy       = var.force_destroy_on_deletion
@@ -37,7 +42,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "flye_metadata_enc
   bucket = aws_s3_bucket.flyte_metadata.bucket
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = local.s3_server_side_encryption
+      kms_master_key_id = local.kms_key_arn
     }
     bucket_key_enabled = false
   }
@@ -88,7 +94,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "flyte_data_encryp
   bucket = aws_s3_bucket.flyte_data.bucket
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = local.s3_server_side_encryption
+      kms_master_key_id = local.kms_key_arn
     }
     bucket_key_enabled = false
   }

--- a/modules/flyte/variables.tf
+++ b/modules/flyte/variables.tf
@@ -58,3 +58,16 @@ variable "serviceaccount_names" {
 
   default = {}
 }
+
+variable "kms_info" {
+  description = <<EOF
+    key_id  = KMS key id.
+    key_arn = KMS key arn.
+    enabled = KMS key is enabled
+  EOF
+  type = object({
+    key_id  = string
+    key_arn = string
+    enabled = bool
+  })
+}


### PR DESCRIPTION
Switch to KMS defaults from SSE-S3, for Flyte

See https://github.com/cerebrotech/platform-apps/pull/8821

https://dominodatalab.atlassian.net/browse/DOM-55148