### PR TITLE
PLAT-8298 - Add EC2 DescribeAddressesAttribute

### DIFF
--- a/modules/eks/submodules/privatelink/aws-load-balancer-controller_2.5.4_iam_policy.json
+++ b/modules/eks/submodules/privatelink/aws-load-balancer-controller_2.5.4_iam_policy.json
@@ -18,6 +18,7 @@
             "Action": [
                 "ec2:DescribeAccountAttributes",
                 "ec2:DescribeAddresses",
+                "ec2:DescribeAddressesAttribute",
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeInternetGateways",
                 "ec2:DescribeVpcs",

--- a/modules/iam-bootstrap/bootstrap-1.json
+++ b/modules/iam-bootstrap/bootstrap-1.json
@@ -110,6 +110,7 @@
         "ec2:Describe*",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAddresses",
+        "ec2:DescribeAddressesAttribute",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",


### PR DESCRIPTION
### Link to JIRA

[PLAT-8298](https://dominodatalab.atlassian.net/browse/PLAT-8298)

### What issue does this pull request solve?

During deployment, there can be errors stating the role is ```not authorized to perform: ec2:DescribeAddressesAttribute because no identity-based policy allows the ec2:DescribeAddressesAttribute action```

### What is the solution?

Add this action to iam-deployment-policies

[PLAT-8298]: https://dominodatalab.atlassian.net/browse/PLAT-8298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ