### PR TITLE
move IAM bootstrap rules for ECR to avoid limit

### DIFF
--- a/.github/workflows/terraform-checks.yml
+++ b/.github/workflows/terraform-checks.yml
@@ -118,3 +118,9 @@ jobs:
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
         env:
           CCI_TOKEN: ${{ secrets.CIRCLE_PERSONAL_TOKEN }}
+  validate-iam-bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Validate IAM bootstrap
+        run: bin/pre-commit/validate-iam-bootstrap.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,3 +74,8 @@ repos:
         entry: ./bin/pre-commit/check-aws-partition.sh
         language: script
         exclude: '^(bin|examples)'
+      - id: validate_iam_bootstrap
+        name: Validate IAM bootstrap
+        entry: ./bin/pre-commit/validate-iam-bootstrap.py
+        language: python
+        pass_filenames: false

--- a/bin/pre-commit/validate-iam-bootstrap.py
+++ b/bin/pre-commit/validate-iam-bootstrap.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import json
+from glob import glob
+
+for bootstrap in glob("modules/iam-bootstrap/bootstrap-*.json"):
+    text = json.loads(Path(bootstrap).read_text())
+    if len(json.dumps(text, separators=(",", ":"))) > 6000:
+        raise SystemExit(
+            f"{bootstrap} is over 6k characters, make sure it's under the IAM PolicySize quota (6144)"
+        )

--- a/modules/iam-bootstrap/bootstrap-1.json
+++ b/modules/iam-bootstrap/bootstrap-1.json
@@ -142,27 +142,6 @@
       "Resource": ["*"]
     },
     {
-      "Sid": "ECRUngated",
-      "Effect": "Allow",
-      "Action": [
-        "ecr:CreatePullThroughCacheRule",
-        "ecr:DescribePullThroughCacheRules"
-      ],
-      "Resource": ["*"]
-    },
-    {
-      "Sid": "ECRGated",
-      "Effect": "Allow",
-      "Action": [
-        "ecr:CreateRepository",
-        "ecr:DescribeRepositories",
-        "ecr:ListTagsForResource",
-        "ecr:TagResource",
-        "ecr:UntagResource"
-      ],
-      "Resource": ["arn:${partition}:ecr:*:*:repository/${deploy_id}/*"]
-    },
-    {
       "Sid": "KMSUngated",
       "Effect": "Allow",
       "Action": [

--- a/modules/iam-bootstrap/bootstrap-2.json
+++ b/modules/iam-bootstrap/bootstrap-2.json
@@ -52,6 +52,27 @@
       "Resource": [
         "*"
       ]
+    },
+    {
+      "Sid": "ECRGated",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:CreateRepository",
+        "ecr:DescribeRepositories",
+        "ecr:ListTagsForResource",
+        "ecr:TagResource",
+        "ecr:UntagResource"
+      ],
+      "Resource": ["arn:${partition}:ecr:*:*:repository/${deploy_id}/*"]
+    },
+    {
+      "Sid": "ECRUngated",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:CreatePullThroughCacheRule",
+        "ecr:DescribePullThroughCacheRules"
+      ],
+      "Resource": ["*"]
     }
   ]
 }


### PR DESCRIPTION
Adding the new ECR rule in #245 put us over the character limit.
Before:
```
$ for i in modules/iam-bootstrap/bootstrap-*.json; do echo -n "$i: " && jq '.' -c "$i" | wc -c; done
modules/iam-bootstrap/bootstrap-0.json: 3338
modules/iam-bootstrap/bootstrap-1.json: 6279
modules/iam-bootstrap/bootstrap-2.json: 948
```

After:
```
$ for i in modules/iam-bootstrap/bootstrap-*.json; do echo -n "$i: " && jq '.' -c "$i" | wc -c; done
modules/iam-bootstrap/bootstrap-0.json: 3338
modules/iam-bootstrap/bootstrap-1.json: 5917
modules/iam-bootstrap/bootstrap-2.json: 1310
```