### PR TITLE
pull through cache for tigera-operator on quay

### DIFF
--- a/modules/eks/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/modules/eks/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -121,6 +121,7 @@ install_calico() {
       --set installation.cni.type=AmazonVPC \
       --set installation.registry="${calico_image_registry}/" \
       --set installation.fipsMode="${calico_fips_mode}" \
+      --set tigeraOperator.registry="${calico_image_registry}" \
       --wait \
       --timeout 10m \
       --create-namespace \


### PR DESCRIPTION
follow-up from #245, tigera-operator has its own specification for the upstream image.