### PR TITLE
[DOM-58654] - updated tagging permissions

### DIFF
--- a/modules/iam-bootstrap/bootstrap-0.json
+++ b/modules/iam-bootstrap/bootstrap-0.json
@@ -126,7 +126,9 @@
         "logs:ListTagsForResource",
         "logs:PutRetentionPolicy",
         "logs:TagLogGroup",
-        "logs:TagResource"
+        "logs:UntagLogGroup",
+        "logs:TagResource",
+        "logs:UntagResource"
       ],
       "Resource": "*"
     },

--- a/modules/iam-bootstrap/bootstrap-0.json
+++ b/modules/iam-bootstrap/bootstrap-0.json
@@ -125,7 +125,8 @@
         "logs:ListTagsLogGroup",
         "logs:ListTagsForResource",
         "logs:PutRetentionPolicy",
-        "logs:TagLogGroup"
+        "logs:TagLogGroup",
+        "logs:TagResource"
       ],
       "Resource": "*"
     },

--- a/modules/iam-bootstrap/bootstrap-1.json
+++ b/modules/iam-bootstrap/bootstrap-1.json
@@ -224,7 +224,9 @@
         "glue:GetTable",
         "glue:DeleteTable",
         "glue:GetCrawler",
-        "glue:DeleteCrawler"
+        "glue:DeleteCrawler",
+        "glue:TagResource",
+        "glue:UntagResource"
       ],
       "Resource": [
         "arn:${partition}:glue:*:*:catalog",


### PR DESCRIPTION
### problem
terraform upgrades is failing during upgrades when cloud_billing resources are avaiable due to missing permissions.

### solution
update deployment role to include tagging permissions.