### PR TITLE
PLAT-8786: Add 1053 to node security group for vcluster's coredns

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -145,6 +145,22 @@ locals {
       type        = "ingress"
       self        = true
     }
+    ingress_self_coredns_tcp = {
+      description = "Node to node vcluster CoreDNS"
+      protocol    = "tcp"
+      from_port   = 1053
+      to_port     = 1053
+      type        = "ingress"
+      self        = true
+    }
+    ingress_self_coredns_udp = {
+      description = "Node to node vcluster CoreDNS"
+      protocol    = "udp"
+      from_port   = 1053
+      to_port     = 1053
+      type        = "ingress"
+      self        = true
+    }
     inter_node_traffic_in_80 = {
       description = "Node to node http traffic"
       protocol    = "tcp"

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -145,7 +145,7 @@ locals {
       type        = "ingress"
       self        = true
     }
-    ingress_self_coredns_tcp = {
+    ingress_self_vcluster_coredns_tcp = {
       description = "Node to node vcluster CoreDNS"
       protocol    = "tcp"
       from_port   = 1053
@@ -153,7 +153,7 @@ locals {
       type        = "ingress"
       self        = true
     }
-    ingress_self_coredns_udp = {
+    ingress_self_vcluster_coredns_udp = {
       description = "Node to node vcluster CoreDNS"
       protocol    = "udp"
       from_port   = 1053


### PR DESCRIPTION
Vcluster's coredns has a target port of 1053, so when using vcluster dns will fail across nodes. This current impacts data plane, and if CI is converted to terraform would be an issue there too.