### PR TITLE
Ignore storage_capacity updates

### DIFF
--- a/modules/infra/submodules/storage/netapp.tf
+++ b/modules/infra/submodules/storage/netapp.tf
@@ -85,7 +85,7 @@ resource "aws_fsx_ontap_file_system" "eks" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [throughput_capacity]
+    ignore_changes        = [storage_capacity]
   }
 
   tags = {


### PR DESCRIPTION
As a result of the fsx filesystem dynamic sizing, terraform tries to reconcile the configuration which causes an error
```
2024-09-10 15:27:06,074 - Error: updating FSx for NetApp ONTAP File System (fs-04a3746d7459eeda4): operation error FSx: UpdateFileSystem, https response error StatusCode: 400, RequestID: d50b73c2-6c70-4afa-9119-d7411595d895, BadRequest: Invalid desired storage capacity provided: 1024 GiB. Desired storage capacity must be at least 10% higher than the existing value of 1331 GiB.
```
This is due to the automatic sizing increasing the capacity and then terraform tries to set it to the configured value.

This change ignores  changes to the `storage_capacity` field which means that we solely rely on the automatic sizing for `storage_capacity` increases.

Also removing `throughput_capacity` given it only affects V2(we are using V1) and should eventually get fixed anyway
https://github.com/hashicorp/terraform-provider-aws/issues/38663