### PR TITLE
PLAT-8779 AL2023 gpu support

### DIFF
--- a/modules/nodes/nodes.tf
+++ b/modules/nodes/nodes.tf
@@ -73,7 +73,7 @@ data "aws_ssm_parameter" "eks_ami_release_version" {
 }
 
 data "aws_ssm_parameter" "eks_gpu_ami_release_version" {
-  name = "/aws/service/eks/optimized-ami/${var.eks_info.cluster.version}/amazon-linux-2-gpu/recommended/release_version"
+  name = "/aws/service/eks/optimized-ami/${var.eks_info.cluster.version}/amazon-linux-2023/x86_64/nvidia/recommended/release_version"
 }
 
 resource "aws_eks_node_group" "node_groups" {

--- a/modules/nodes/nodes.tf
+++ b/modules/nodes/nodes.tf
@@ -91,7 +91,7 @@ resource "aws_eks_node_group" "node_groups" {
     desired_size = each.value.node_group.desired_per_az
   }
 
-  ami_type       = each.value.node_group.ami != null ? "CUSTOM" : each.value.node_group.gpu ? "AL2_x86_64_GPU" : "AL2023_x86_64_STANDARD"
+  ami_type       = each.value.node_group.ami != null ? "CUSTOM" : each.value.node_group.gpu ? "AL2023_x86_64_NVIDIA" : "AL2023_x86_64_STANDARD"
   capacity_type  = each.value.node_group.spot ? "SPOT" : "ON_DEMAND"
   instance_types = each.value.node_group.instance_types
   launch_template {


### PR DESCRIPTION
https://dominodatalab.atlassian.net/browse/PLAT-8779

Adds al2023 GPU support


```
aws ec2 describe-images --region us-west-2 --image-ids "$(kubectl get nodes -l dominodatalab.com/node-pool=default-gpu -o json | jq -r '.items[].metadata.labels["eks.amazonaws.com/nodegroup-image"]')"
{
    "Images": [
        {
            "Architecture": "x86_64",
            "CreationDate": "2024-09-29T02:26:16.000Z",
            "ImageId": "ami-03b91bc878422278e",
            "ImageLocation": "amazon/amazon-eks-node-al2023-x86_64-nvidia-560-1.30-v20240928",
            "ImageType": "machine",
            "Public": true,
            "OwnerId": "602401143452",
            "PlatformDetails": "Linux/UNIX",
            "UsageOperation": "RunInstances",
            "State": "available",
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/xvda",
                    "Ebs": {
                        "DeleteOnTermination": true,
                        "Iops": 3000,
                        "SnapshotId": "snap-0f5c615a9e9596469",
                        "VolumeSize": 20,
                        "VolumeType": "gp3",
                        "Throughput": 125,
                        "Encrypted": false
                    }
                }
            ],
            "Description": "EKS-optimized Kubernetes node based on Amazon Linux 2023, (k8s: 1.30.4, containerd: 1.7.11-*)",
            "EnaSupport": true,
            "Hypervisor": "xen",
            "ImageOwnerAlias": "amazon",
            "Name": "amazon-eks-node-al2023-x86_64-nvidia-560-1.30-v20240928",
            "RootDeviceName": "/dev/xvda",
            "RootDeviceType": "ebs",
            "SriovNetSupport": "simple",
            "VirtualizationType": "hvm",
            "BootMode": "uefi-preferred",
            "DeprecationTime": "2026-09-29T02:26:16.000Z",
            "ImdsSupport": "v2.0"
        }
    ]
}
```