### PR TITLE
only use base AL2023 for bastion

### DIFF
--- a/modules/infra/submodules/bastion/README.md
+++ b/modules/infra/submodules/bastion/README.md
@@ -38,11 +38,11 @@ No modules.
 | [aws_security_group_rule.bastion_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [null_resource.install_binaries](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [terraform_data.check_bastion_instance_profile](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
-| [aws_ami.al2023](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.aws_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.bastion_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_ssm_parameter.al2023_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 

--- a/modules/infra/submodules/bastion/main.tf
+++ b/modules/infra/submodules/bastion/main.tf
@@ -130,24 +130,13 @@ resource "terraform_data" "check_bastion_instance_profile" {
   depends_on = [aws_iam_instance_profile.bastion]
 }
 
-data "aws_ami" "al2023" {
-  count       = var.bastion.ami_id == null ? 1 : 0
-  most_recent = true
-  owners      = ["amazon"]
 
-  filter {
-    name   = "name"
-    values = ["al2023-ami-2023*"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
+data "aws_ssm_parameter" "al2023_ami" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64"
 }
 
 locals {
-  ami_id = var.bastion.ami_id != null ? var.bastion.ami_id : data.aws_ami.al2023[0].id
+  ami_id = var.bastion.ami_id != null ? var.bastion.ami_id : data.aws_ssm_parameter.al2023_ami.value
 }
 
 resource "aws_instance" "bastion" {

--- a/modules/infra/submodules/bastion/main.tf
+++ b/modules/infra/submodules/bastion/main.tf
@@ -137,7 +137,7 @@ data "aws_ami" "al2023" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami*"]
+    values = ["al2023-ami-2023*"]
   }
 
   filter {


### PR DESCRIPTION
`al2023-ami*` will pick up ECS/Neuron AMIs. It's pretty harmless, but in the interest of consistency.

```
$ aws ec2 describe-images --owners amazon --region us-west-2 --filters Name=name,Values=al2023-ami-* Name=architecture,Values=x86_64 --query 'sort_by(Images, &CreationDate)[0].Name' --page-size 1000
"al2023-ami-ecs-neuron-hvm-2023.0.20230406-kernel-6.1-x86_64"

$ aws ec2 describe-images --owners amazon --region us-west-2 --filters Name=name,Values=al2023-ami-2023* Name=architecture,Values=x86_64 --query 'sort_by(Images, &CreationDate)[0].Name' --page-size 1000
"al2023-ami-2023.5.20240722.0-kernel-6.1-x86_64"
```

I added a commit using SSM parameters if that's simpler: f8d291f.