### PR TITLE
replace - with _ on volume names

### DIFF
--- a/modules/infra/submodules/storage/netapp.tf
+++ b/modules/infra/submodules/storage/netapp.tf
@@ -154,7 +154,7 @@ resource "aws_fsx_ontap_storage_virtual_machine" "eks" {
 resource "aws_fsx_ontap_volume" "eks" {
   count                      = local.deploy_netapp && var.storage.netapp.volume.create ? 1 : 0
   storage_virtual_machine_id = aws_fsx_ontap_storage_virtual_machine.eks[0].id
-  name                       = replace("${var.deploy_id}_${var.storage.netapp.volume.name_suffix}", "/[^a-z_]/", "_")
+  name                       = replace("${var.deploy_id}_${var.storage.netapp.volume.name_suffix}", "/[^a-zA-z0-9_]/", "_")
   junction_path              = var.storage.netapp.volume.junction_path
   size_in_megabytes          = var.storage.netapp.volume.size_in_megabytes
   storage_efficiency_enabled = true

--- a/modules/infra/submodules/storage/netapp.tf
+++ b/modules/infra/submodules/storage/netapp.tf
@@ -154,7 +154,7 @@ resource "aws_fsx_ontap_storage_virtual_machine" "eks" {
 resource "aws_fsx_ontap_volume" "eks" {
   count                      = local.deploy_netapp && var.storage.netapp.volume.create ? 1 : 0
   storage_virtual_machine_id = aws_fsx_ontap_storage_virtual_machine.eks[0].id
-  name                       = replace("${var.deploy_id}_${var.storage.netapp.volume.name_suffix}", "-", "_")
+  name                       = replace("${var.deploy_id}_${var.storage.netapp.volume.name_suffix}", "/[^a-z_]/", "_")
   junction_path              = var.storage.netapp.volume.junction_path
   size_in_megabytes          = var.storage.netapp.volume.size_in_megabytes
   storage_efficiency_enabled = true

--- a/modules/infra/submodules/storage/netapp.tf
+++ b/modules/infra/submodules/storage/netapp.tf
@@ -154,7 +154,7 @@ resource "aws_fsx_ontap_storage_virtual_machine" "eks" {
 resource "aws_fsx_ontap_volume" "eks" {
   count                      = local.deploy_netapp && var.storage.netapp.volume.create ? 1 : 0
   storage_virtual_machine_id = aws_fsx_ontap_storage_virtual_machine.eks[0].id
-  name                       = "${var.deploy_id}_${var.storage.netapp.volume.name_suffix}"
+  name                       = replace("${var.deploy_id}_${var.storage.netapp.volume.name_suffix}", "-", "_")
   junction_path              = var.storage.netapp.volume.junction_path
   size_in_megabytes          = var.storage.netapp.volume.size_in_megabytes
   storage_efficiency_enabled = true


### PR DESCRIPTION
Avoids failure incase the deployid contains `-`

```
Error: creating FSx for NetApp ONTAP Volume (netapp-poc_domino_shared_storage): operation error FSx: CreateVolume, https response error StatusCode: 400, RequestID: 54d9520f-2f83-4cfc-b9b9-9e43b7874cdb, BadRequest: netapp-poc_domino_shared_storage is not a valid volume name. A volume name must begin with a letter or underscore, can only contain alphanumeric characters or "_", and cannot exceed 203 characters in length.
```