### PR TITLE
PLAT-8958 fix helm install nor retrying

### DIFF
--- a/modules/eks/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/modules/eks/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -111,7 +111,9 @@ install_calico() {
   local sleep_duration=10
 
   for i in $(seq 1 $max_retries); do
-    helm_cmd upgrade "calico-tigera-operator" \
+    echo "Attempt $i of $max_retries..."
+
+    if helm_cmd upgrade "calico-tigera-operator" \
       tigera-operator \
       --repo "https://projectcalico.docs.tigera.io/charts" \
       --version "${calico_version}" \
@@ -125,20 +127,20 @@ install_calico() {
       --wait \
       --timeout 10m \
       --create-namespace \
-      --install
+      --install; then
 
-    if [ $? -eq 0 ]; then
+      echo "Calico installation succeeded."
       break
-    fi
-
-    if [ $i -lt $max_retries ]; then
-      echo "Attempt $i failed. Retrying in $${sleep_duration}s..."
-      sleep $sleep_duration
     else
-      printf "$RED Maximum attempts reached. Exiting. $EC \n"
-      exit 1
+      echo "Helm install attempt $i failed."
+      if [ $i -lt $max_retries ]; then
+        echo "Retrying in ${sleep_duration}s..."
+        sleep $sleep_duration
+      else
+        printf "$RED Maximum attempts reached. Exiting. $EC \n"
+        exit 1
+      fi
     fi
-
   done
 }
 

--- a/modules/eks/submodules/k8s/templates/k8s-functions.sh.tftpl
+++ b/modules/eks/submodules/k8s/templates/k8s-functions.sh.tftpl
@@ -2,6 +2,7 @@
 
 RED="\e[31m"
 GREEN="\e[32m"
+YELLOW="\e[33m"
 EC="\e[0m"
 
 KUBECONFIG="${kubeconfig_path}"
@@ -129,17 +130,20 @@ install_calico() {
       --create-namespace \
       --install; then
 
-      echo "Calico installation succeeded."
+      printf "$GREEN Calico installation succeeded. $EC \n"
       break
+
     else
-      echo "Helm install attempt $i failed."
+      printf "$YELLOW Helm install attempt $i failed. $EC \n"
+
       if [ $i -lt $max_retries ]; then
-        echo "Retrying in ${sleep_duration}s..."
+        printf "Retrying in $sleep_duration s..."
         sleep $sleep_duration
       else
         printf "$RED Maximum attempts reached. Exiting. $EC \n"
         exit 1
       fi
+
     fi
   done
 }


### PR DESCRIPTION
[PLAT-8958](https://dominodatalab.atlassian.net/browse/PLAT-8958)
Given the caller script has `set -e` it does not let the helm install retry as the execution is halted.