### PR TITLE
PLAT-8781: Give importer access to flytepropeller

### DIFF
--- a/modules/flyte/README.md
+++ b/modules/flyte/README.md
@@ -54,7 +54,7 @@ No modules.
 | <a name="input_kms_info"></a> [kms\_info](#input\_kms\_info) | key\_id  = KMS key id.<br>    key\_arn = KMS key arn.<br>    enabled = KMS key is enabled | <pre>object({<br>    key_id  = string<br>    key_arn = string<br>    enabled = bool<br>  })</pre> | n/a | yes |
 | <a name="input_platform_namespace"></a> [platform\_namespace](#input\_platform\_namespace) | Name of Domino platform namespace for this deploy | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region for the deployment | `string` | n/a | yes |
-| <a name="input_serviceaccount_names"></a> [serviceaccount\_names](#input\_serviceaccount\_names) | Service account names for Flyte | <pre>object({<br>    datacatalog    = optional(string, "datacatalog")<br>    flyteadmin     = optional(string, "flyteadmin")<br>    flytepropeller = optional(string, "flytepropeller")<br>  })</pre> | `{}` | no |
+| <a name="input_serviceaccount_names"></a> [serviceaccount\_names](#input\_serviceaccount\_names) | Service account names for Flyte | <pre>object({<br>    datacatalog    = optional(string, "datacatalog")<br>    flyteadmin     = optional(string, "flyteadmin")<br>    flytepropeller = optional(string, "flytepropeller")<br>    importer       = optional(string, "domino-data-importer")<br>  })</pre> | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Deployment tags. | `map(string)` | `{}` | no |
 | <a name="input_use_fips_endpoint"></a> [use\_fips\_endpoint](#input\_use\_fips\_endpoint) | Use aws FIPS endpoints | `bool` | `false` | no |
 

--- a/modules/flyte/iam.tf
+++ b/modules/flyte/iam.tf
@@ -15,6 +15,7 @@ resource "aws_iam_role" "flyte_controlplane" {
             "${trimprefix(local.oidc_provider_url, "https://")}:sub" : [
               "system:serviceaccount:${var.platform_namespace}:${var.serviceaccount_names.datacatalog}",
               "system:serviceaccount:${var.platform_namespace}:${var.serviceaccount_names.flytepropeller}",
+              "system:serviceaccount:${var.platform_namespace}:${var.serviceaccount_names.importer}",
             ]
           }
         }

--- a/modules/flyte/variables.tf
+++ b/modules/flyte/variables.tf
@@ -54,6 +54,7 @@ variable "serviceaccount_names" {
     datacatalog    = optional(string, "datacatalog")
     flyteadmin     = optional(string, "flyteadmin")
     flytepropeller = optional(string, "flytepropeller")
+    importer       = optional(string, "domino-data-importer")
   })
 
   default = {}


### PR DESCRIPTION
Importer needs access to flyte buckets for lift-and-shift in 6.0.1 too