### PR TITLE
Update external-deployments operator role policies (6.0.1 backport)

### DIFF
--- a/examples/deploy/set-mod-version.sh
+++ b/examples/deploy/set-mod-version.sh
@@ -23,7 +23,7 @@ validate_mod_version() {
     fi
 
     local tag_array=()
-    mapfile -t tag_array <<<$("${curl_cmd[@]}" "$url" | jq -r '.[].name | select(test("^v\\d+\\.\\d+\\.\\d+$"))')
+    mapfile -t tag_array <<<$("${curl_cmd[@]}" "$url" | jq -r '.[].name | select(test("^v\\d+\\.\\d+\\.\\d+(-\\d+)?$"))')
 
     for tag in "${tag_array[@]}"; do
       [[ "$MOD_VERSION" == "$tag" ]] && return

--- a/modules/external-deployments/operator_role_policies.tf
+++ b/modules/external-deployments/operator_role_policies.tf
@@ -110,6 +110,9 @@ data "aws_iam_policy_document" "in_account_policies" {
       "sagemaker:DescribeModel",
       "sagemaker:InvokeEndpoint",
       "sagemaker:InvokeEndpointWithResponseStream",
+      "sagemaker:ListEndpointConfigs",
+      "sagemaker:ListEndpoints",
+      "sagemaker:ListModels",
       "sagemaker:UpdateEndpoint",
       "sagemaker:UpdateEndpointWeightsAndCapacities"
     ]


### PR DESCRIPTION
Backport of https://github.com/dominodatalab/terraform-aws-eks/pull/293 (and https://github.com/dominodatalab/terraform-aws-eks/pull/298)

This PR https://github.com/cerebrotech/pham-juno-operator-service/pull/161 changes the clean-up process in a way that requires allowing the operator to be able to list Models and EndpointConfigs rather than only describing them.