### PR TITLE
PLAT-9010 - Pin aws provider due to eks.kubernetes_network_config change in v5.79.0

### DIFF
--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0, < 5.79 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.1.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
@@ -14,8 +14,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
-| <a name="provider_aws.eks"></a> [aws.eks](#provider\_aws.eks) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0, < 5.79 |
+| <a name="provider_aws.eks"></a> [aws.eks](#provider\_aws.eks) | >= 5.0, < 5.79 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.1.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |

--- a/modules/eks/versions.tf
+++ b/modules/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 5.0"
+      version               = ">= 5.0, < 5.79"
       configuration_aliases = [aws.eks]
     }
     null = {


### PR DESCRIPTION
There is an update to the schema in  `eks.kubernetes_network_config` on release `5.79.0` https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.79.0.
this change pins the version while we work on the future compatibility