### PR TITLE
PLAT-9026 managed_policy_arns deprecated

### DIFF
--- a/modules/iam-bootstrap/README.md
+++ b/modules/iam-bootstrap/README.md
@@ -24,6 +24,7 @@ No modules.
 |------|------|
 | [aws_iam_policy.deployment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.deployment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachments_exclusive.deployment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
 | [aws_caller_identity.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 

--- a/modules/iam-bootstrap/main.tf
+++ b/modules/iam-bootstrap/main.tf
@@ -41,7 +41,11 @@ resource "aws_iam_role" "deployment" {
     ]
   })
 
-  managed_policy_arns = aws_iam_policy.deployment[*].arn
-
   max_session_duration = var.max_session_duration
+}
+
+
+resource "aws_iam_role_policy_attachments_exclusive" "deployment" {
+  role_name   = aws_iam_role.deployment.name
+  policy_arns = aws_iam_policy.deployment[*].arn
 }


### PR DESCRIPTION
[PLAT-9026](https://dominodatalab.atlassian.net/browse/PLAT-9026)

```
2024-12-05 00:57:57,961 - Warning: Argument is deprecated
2024-12-05 00:57:57,961 - 
2024-12-05 00:57:57,961 -   with module.iam_bootstrap.aws_iam_role.deployment,
2024-12-05 00:57:57,961 -   on /resources/deployer/deploys/platst71497/iam_bootstrap/terraform/modules/iam_bootstrap/modules/iam-bootstrap/main.tf line 44, in resource "aws_iam_role" "deployment":
2024-12-05 00:57:57,961 -   44:   managed_policy_arns = aws_iam_policy.deployment[*].arn
2024-12-05 00:57:57,961 - 
2024-12-05 00:57:57,961 - The managed_policy_arns argument is deprecated. Use the
2024-12-05 00:57:57,961 - aws_iam_role_policy_attachment resource instead. If Terraform should
2024-12-05 00:57:57,961 - exclusively manage all managed policy attachments (the current behavior of
2024-12-05 00:57:57,961 - this argument), use the aws_iam_role_policy_attachments_exclusive resource as
```