### PR TITLE
Trim ecr_repository_prefix to aws_ecr_pull_through_cache_rule limitation

### DIFF
--- a/modules/infra/submodules/storage/ecr.tf
+++ b/modules/infra/submodules/storage/ecr.tf
@@ -28,7 +28,7 @@ resource "aws_ecr_repository" "this" {
 
 resource "aws_ecr_pull_through_cache_rule" "quay" {
   count                 = local.supports_pull_through_cache ? 1 : 0
-  ecr_repository_prefix = "${var.deploy_id}/quay"
+  ecr_repository_prefix = "${substr(var.deploy_id, 0, 24)}/quay"
   upstream_registry_url = "quay.io"
 }
 


### PR DESCRIPTION
```
│ Error: expected length of ecr_repository_prefix to be in the range (2 - 30), got secure-ami-127-12585649125-1/quay
│ 
│   with module.infra.module.storage.aws_ecr_pull_through_cache_rule.quay[0],
│   on .terraform/modules/infra/modules/infra/submodules/storage/ecr.tf line 31, in resource "aws_ecr_pull_through_cache_rule" "quay":
│   31:   ecr_repository_prefix = "${var.deploy_id}/quay"
```