### PR TITLE
Conditionally reference the aws_vpc_endpoint.s3

### DIFF
--- a/modules/infra/submodules/network/outputs.tf
+++ b/modules/infra/submodules/network/outputs.tf
@@ -16,7 +16,7 @@ output "info" {
     eips      = [for k, eip in aws_eip.public : eip.public_ip]
     vpc_cidrs = var.network.cidrs.vpc
     pod_cidrs = var.network.cidrs.pod
-    s3_cidrs  = data.aws_prefix_list.s3.cidr_blocks
+    s3_cidrs  = local.create_vpc ? data.aws_prefix_list.s3[0].cidr_blocks : null
     ecr_endpoint = local.create_ecr_endpoint ? {
       security_group_id = aws_security_group.ecr_endpoint[0].id
     } : null

--- a/modules/infra/submodules/network/vpc.tf
+++ b/modules/infra/submodules/network/vpc.tf
@@ -50,6 +50,7 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 data "aws_prefix_list" "s3" {
+  count          = local.create_vpc ? 1 : 0
   prefix_list_id = aws_vpc_endpoint.s3[0].prefix_list_id
 }
 


### PR DESCRIPTION
```
plan: 32 to add, 4 to change, 0 to destroy.
╷
│ Error: Invalid index
│
│   on .terraform/modules/infra/modules/infra/submodules/network/vpc.tf line 53, in data "aws_prefix_list" "s3":
│   53:   prefix_list_id = aws_vpc_endpoint.s3[0].prefix_list_id
│     ├────────────────
│     │ aws_vpc_endpoint.s3 is empty tuple
│
│ The given key does not identify an element in this collection value: the collection has no elements.
```