### PR TITLE
feat: enable specifying irsa or role permissions for flyte module

### DIFF
--- a/modules/flyte/README.md
+++ b/modules/flyte/README.md
@@ -23,20 +23,25 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.flyte_combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.flyte_controlplane](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.flyte_dataplane](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.flyte_controlplane](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.flyte_dataplane](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.flyte_controlplane](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.flyte_dataplane](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.flyte_node_role_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_bucket.flyte_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.flyte_metadata](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_cors_configuration.flyte_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
 | [aws_s3_bucket_policy.flyte_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.flyte_metadata](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.flye_metadata_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.flyte_data_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.flyte_metadata_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_caller_identity.aws_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster.domino_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_iam_openid_connect_provider.domino_cluster_issuer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
+| [aws_iam_policy_document.flyte_combined_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.flyte_controlplane](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.flyte_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.flyte_dataplane](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -48,12 +53,14 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_compute_namespace"></a> [compute\_namespace](#input\_compute\_namespace) | Name of Domino compute namespace for this deploy | `string` | n/a | yes |
-| <a name="input_eks_info"></a> [eks\_info](#input\_eks\_info) | cluster = {<br>      specs {<br>        name            = Cluster name.<br>        account\_id      = AWS account id where the cluster resides.<br>      }<br>      oidc = {<br>        arn = OIDC provider ARN.<br>        url = OIDC provider url.<br>        cert = {<br>          thumbprint\_list = OIDC cert thumbprints.<br>          url             = OIDC cert URL.<br>      }<br>    } | <pre>object({<br>    cluster = object({<br>      specs = object({<br>        name       = string<br>        account_id = string<br>      })<br>      oidc = object({<br>        arn = string<br>        url = string<br>        cert = object({<br>          thumbprint_list = list(string)<br>          url             = string<br>        })<br>      })<br>    })<br>  })</pre> | n/a | yes |
+| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | Name of the EKS cluster running Domino workloads | `string` | n/a | yes |
+| <a name="input_enable_irsa"></a> [enable\_irsa](#input\_enable\_irsa) | Whether to assume AWS EKS IRSA is configured; if not, attach permissions to target\_iam\_role\_name. | `bool` | `false` | no |
 | <a name="input_force_destroy_on_deletion"></a> [force\_destroy\_on\_deletion](#input\_force\_destroy\_on\_deletion) | Whether to force destroy flyte s3 buckets on deletion | `bool` | `true` | no |
-| <a name="input_kms_info"></a> [kms\_info](#input\_kms\_info) | key\_id  = KMS key id.<br>    key\_arn = KMS key arn.<br>    enabled = KMS key is enabled | <pre>object({<br>    key_id  = string<br>    key_arn = string<br>    enabled = bool<br>  })</pre> | n/a | yes |
+| <a name="input_kms_info"></a> [kms\_info](#input\_kms\_info) | key\_id  = KMS key id.<br/>    key\_arn = KMS key arn.<br/>    enabled = KMS key is enabled | <pre>object({<br/>    key_id  = string<br/>    key_arn = string<br/>    enabled = bool<br/>  })</pre> | n/a | yes |
 | <a name="input_platform_namespace"></a> [platform\_namespace](#input\_platform\_namespace) | Name of Domino platform namespace for this deploy | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region for the deployment | `string` | n/a | yes |
-| <a name="input_serviceaccount_names"></a> [serviceaccount\_names](#input\_serviceaccount\_names) | Service account names for Flyte | <pre>object({<br>    datacatalog    = optional(string, "datacatalog")<br>    flyteadmin     = optional(string, "flyteadmin")<br>    flytepropeller = optional(string, "flytepropeller")<br>  })</pre> | `{}` | no |
+| <a name="input_serviceaccount_names"></a> [serviceaccount\_names](#input\_serviceaccount\_names) | Service account names for Flyte | <pre>object({<br/>    datacatalog    = optional(string, "datacatalog")<br/>    flyteadmin     = optional(string, "flyteadmin")<br/>    flytepropeller = optional(string, "flytepropeller")<br/>  })</pre> | `{}` | no |
+| <a name="input_target_iam_role_name"></a> [target\_iam\_role\_name](#input\_target\_iam\_role\_name) | If not using IRSA, attach new policies to this AWS IAM role | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/flyte/migrations.tf
+++ b/modules/flyte/migrations.tf
@@ -1,0 +1,4 @@
+moved {
+  from = aws_s3_bucket_server_side_encryption_configuration.flye_metadata_encryption
+  to   = aws_s3_bucket_server_side_encryption_configuration.flyte_metadata_encryption
+}

--- a/modules/flyte/outputs.tf
+++ b/modules/flyte/outputs.tf
@@ -3,7 +3,7 @@ output "eks" {
   value = {
     metadata_bucket       = aws_s3_bucket.flyte_metadata.bucket
     data_bucket           = aws_s3_bucket.flyte_data.bucket
-    controlplane_role_arn = aws_iam_role.flyte_controlplane.arn
-    dataplane_role_arn    = aws_iam_role.flyte_dataplane.arn
+    controlplane_role_arn = one(aws_iam_role.flyte_controlplane[*].arn)
+    dataplane_role_arn    = one(aws_iam_role.flyte_dataplane[*].arn)
   }
 }

--- a/modules/flyte/s3.tf
+++ b/modules/flyte/s3.tf
@@ -38,7 +38,7 @@ resource "aws_s3_bucket_policy" "flyte_metadata" {
   policy = data.aws_iam_policy_document.flyte_metadata.json
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "flye_metadata_encryption" {
+resource "aws_s3_bucket_server_side_encryption_configuration" "flyte_metadata_encryption" {
   bucket = aws_s3_bucket.flyte_metadata.bucket
   rule {
     apply_server_side_encryption_by_default {

--- a/modules/flyte/variables.tf
+++ b/modules/flyte/variables.tf
@@ -4,38 +4,21 @@ variable "force_destroy_on_deletion" {
   default     = true
 }
 
-variable "eks_info" {
-  description = <<EOF
-    cluster = {
-      specs {
-        name            = Cluster name.
-        account_id      = AWS account id where the cluster resides.
-      }
-      oidc = {
-        arn = OIDC provider ARN.
-        url = OIDC provider url.
-        cert = {
-          thumbprint_list = OIDC cert thumbprints.
-          url             = OIDC cert URL.
-      }
-    }
-  EOF
-  type = object({
-    cluster = object({
-      specs = object({
-        name       = string
-        account_id = string
-      })
-      oidc = object({
-        arn = string
-        url = string
-        cert = object({
-          thumbprint_list = list(string)
-          url             = string
-        })
-      })
-    })
-  })
+variable "enable_irsa" {
+  default     = false
+  description = "Whether to assume AWS EKS IRSA is configured; if not, attach permissions to target_iam_role_name."
+  type        = bool
+}
+
+variable "target_iam_role_name" {
+  default     = null
+  description = "If not using IRSA, attach new policies to this AWS IAM role"
+  type        = string
+}
+
+variable "eks_cluster_name" {
+  type        = string
+  description = "Name of the EKS cluster running Domino workloads"
 }
 
 variable "platform_namespace" {


### PR DESCRIPTION
Hi Domino team,

The flyte submodule seems to expect IRSA to be configured on the target EKS cluster. While recommended, there are cases where IRSA isn't installed on an EKS cluster (i.e. following the default Domino EKS installation instructions). This PR allows a user to specify a flag that enables IRSA (disabled by default) and, if disabled, a role to use for attaching the required Flyte S3 policy. If the flag is enabled, instead of requiring the user to specify details about the target cluster, it simply uses the EKS cluster name to pull relevant details from AWS such as the OIDC provider URL/ARN (these can be computed based on the cluster's OIDC endpoint). 

The result is less required variables and support for clusters that do not have EKS IRSA configured.