### PR TITLE
PLAT-9123: Costs module non-kms mode

### DIFF
--- a/modules/iam-bootstrap/bootstrap-2.json
+++ b/modules/iam-bootstrap/bootstrap-2.json
@@ -43,6 +43,7 @@
         "lambda:GetFunctionCodeSigningConfig",
         "lambda:DeleteCodeSigningConfig",
         "lambda:TagResource",
+        "lambda:UntagResource",
         "lambda:ListTags"
       ],
       "Resource": "*"
@@ -63,6 +64,7 @@
         "cur:DescribeReportDefinitions",
         "cur:DeleteReportDefinition",
         "cur:TagResource",
+        "cur:UntagResource",
         "cur:ListTagsForResource"
       ],
       "Resource": [

--- a/modules/iam-bootstrap/bootstrap-2.json
+++ b/modules/iam-bootstrap/bootstrap-2.json
@@ -20,7 +20,6 @@
       "Effect": "Allow",
       "Action": [
         "lambda:CreateFunction",
-        "lambda:TagResource",
         "lambda:GetFunction",
         "lambda:ListVersionsByFunction",
         "lambda:DeleteFunction",
@@ -42,7 +41,9 @@
         "lambda:UpdateCodeSigningConfig",
         "lambda:GetCodeSigningConfig",
         "lambda:GetFunctionCodeSigningConfig",
-        "lambda:DeleteCodeSigningConfig"
+        "lambda:DeleteCodeSigningConfig",
+        "lambda:TagResource",
+        "lambda:ListTags"
       ],
       "Resource": "*"
     },
@@ -60,7 +61,9 @@
       "Action": [
         "cur:PutReportDefinition",
         "cur:DescribeReportDefinitions",
-        "cur:DeleteReportDefinition"
+        "cur:DeleteReportDefinition",
+        "cur:TagResource",
+        "cur:ListTagsForResource"
       ],
       "Resource": [
         "*"

--- a/modules/infra/submodules/cost-usage-report/glue.tf
+++ b/modules/infra/submodules/cost-usage-report/glue.tf
@@ -15,13 +15,13 @@ resource "aws_glue_security_configuration" "lambda_config" {
 
   encryption_configuration {
     cloudwatch_encryption {
-      cloudwatch_encryption_mode = "SSE-KMS"
-      kms_key_arn                = var.kms_info.key_arn
+      cloudwatch_encryption_mode = var.kms_info.enabled ? "SSE-KMS" : "DISABLED"
+      kms_key_arn                = local.kms_key_arn
     }
 
     job_bookmarks_encryption {
-      job_bookmarks_encryption_mode = "CSE-KMS"
-      kms_key_arn                   = var.kms_info.key_arn
+      job_bookmarks_encryption_mode = var.kms_info.enabled ? "CSE-KMS" : "DISABLED"
+      kms_key_arn                   = local.kms_key_arn
     }
 
     s3_encryption {

--- a/modules/infra/submodules/cost-usage-report/glue.tf
+++ b/modules/infra/submodules/cost-usage-report/glue.tf
@@ -15,17 +15,17 @@ resource "aws_glue_security_configuration" "lambda_config" {
 
   encryption_configuration {
     cloudwatch_encryption {
-      cloudwatch_encryption_mode = "SSE-KMS"
+      cloudwatch_encryption_mode = var.kms_info.enabled ? "SSE-KMS" : "DISABLED"
       kms_key_arn                = local.kms_key_arn
     }
 
     job_bookmarks_encryption {
-      job_bookmarks_encryption_mode = "CSE-KMS"
+      job_bookmarks_encryption_mode = var.kms_info.enabled ? "CSE-KMS" : "DISABLED"
       kms_key_arn                   = local.kms_key_arn
     }
 
     s3_encryption {
-      s3_encryption_mode = "SSE-KMS"
+      s3_encryption_mode = var.kms_info.enabled ? "SSE-KMS" : "SSE-S3"
       kms_key_arn        = local.kms_key_arn
     }
   }
@@ -117,7 +117,7 @@ resource "aws_athena_workgroup" "athena_work_group" {
       output_location = "s3://${aws_s3_bucket.athena_result.bucket}/"
 
       encryption_configuration {
-        encryption_option = "SSE_KMS"
+        encryption_option = var.kms_info.enabled ? "SSE_KMS" : "SSE_S3"
         kms_key_arn       = local.kms_key_arn
       }
     }

--- a/modules/infra/submodules/cost-usage-report/glue.tf
+++ b/modules/infra/submodules/cost-usage-report/glue.tf
@@ -11,6 +11,7 @@ resource "aws_glue_catalog_database" "aws_cur_database" {
 
 
 resource "aws_glue_security_configuration" "lambda_config" {
+  # checkov:skip=CKV_AWS_99:Ensure Glue Security Configuration Encryption is enabled
   name = "${var.deploy_id}_lambda_security_config"
 
   encryption_configuration {

--- a/modules/infra/submodules/cost-usage-report/glue.tf
+++ b/modules/infra/submodules/cost-usage-report/glue.tf
@@ -15,13 +15,13 @@ resource "aws_glue_security_configuration" "lambda_config" {
 
   encryption_configuration {
     cloudwatch_encryption {
-      cloudwatch_encryption_mode = var.kms_info.enabled ? "SSE-KMS" : "DISABLED"
-      kms_key_arn                = local.kms_key_arn
+      cloudwatch_encryption_mode = "SSE-KMS"
+      kms_key_arn                = var.kms_info.key_arn
     }
 
     job_bookmarks_encryption {
-      job_bookmarks_encryption_mode = var.kms_info.enabled ? "CSE-KMS" : "DISABLED"
-      kms_key_arn                   = local.kms_key_arn
+      job_bookmarks_encryption_mode = "CSE-KMS"
+      kms_key_arn                   = var.kms_info.key_arn
     }
 
     s3_encryption {


### PR DESCRIPTION
The costs terraform submodule, with cost reporting on, does not currently work when KMS is disabled.

This fixes that so what can use SSE uses SSE, and what can't is simply not encrypted. If you have an issue with the lack of encryption for those things, you should enable KMS, as those two things simply do not support encryption any other way.