### PR TITLE
Fix CIDR outputs for vpc and pod subnets

### DIFF
--- a/modules/infra/submodules/network/outputs.tf
+++ b/modules/infra/submodules/network/outputs.tf
@@ -14,8 +14,8 @@ output "info" {
       pod     = local.pod_route_table_ids
     }
     eips      = [for k, eip in aws_eip.public : eip.public_ip]
-    vpc_cidrs = var.network.cidrs.vpc
-    pod_cidrs = var.network.cidrs.pod
+    vpc_cidrs = local.create_vpc ? aws_vpc.this[0].cidr_block : data.aws_vpc.provided[0].cidr_block
+    pod_cidrs = local.pod_cidr_blocks
     s3_cidrs  = local.create_vpc ? data.aws_prefix_list.s3[0].cidr_blocks : null
     ecr_endpoint = local.create_ecr_endpoint ? {
       security_group_id = aws_security_group.ecr_endpoint[0].id


### PR DESCRIPTION
The `vpc_cidrs` and `pod_cidrs`  being passed through to the outputs which is inaccurate for byo network.