### PR TITLE
Relax network CIDR validation

### DIFF
--- a/examples/tfvars/specify-vpc-cidr.tfvars
+++ b/examples/tfvars/specify-vpc-cidr.tfvars
@@ -1,0 +1,30 @@
+deploy_id        = "plantest018"
+region           = "us-west-2"
+ssh_pvt_key_path = "domino.pem"
+
+default_node_groups = {
+  compute = {
+    availability_zone_ids = ["usw2-az1", "usw2-az2"]
+  }
+  gpu = {
+    availability_zone_ids = ["usw2-az1", "usw2-az2"]
+  }
+  platform = {
+    "availability_zone_ids" = ["usw2-az1", "usw2-az2"]
+  }
+}
+
+bastion = {
+  enabled = true
+}
+network = {
+  network_bits = { ## Bits need to be less than cidrs.vpc bits
+    public  = 27
+    private = 21
+    pod     = 20
+  }
+  cidrs = {
+    vpc = "10.0.0.0/19"
+  }
+  use_pod_cidr = false
+}

--- a/modules/infra/submodules/network/variables.tf
+++ b/modules/infra/submodules/network/variables.tf
@@ -80,9 +80,12 @@ variable "network" {
   })
 
   validation {
-    condition = alltrue([for name, cidr in var.network.cidrs : try(cidrhost(cidr, 0), false) == regex("^(.*)/", cidr)[0] &&
-    try(cidrnetmask(cidr), false) == "255.255.0.0"])
-    error_message = "Each of network.cidrs must be a valid CIDR block."
+    condition = alltrue([
+      for name, cidr in coalesce(var.network.cidrs, {}) :
+      can(cidrhost(cidr, 0)) &&
+      parseint(split("/", cidr)[1], 10) <= 32 && parseint(split("/", cidr)[1], 10) >= 8
+    ])
+    error_message = "Each of network.cidrs must be a valid CIDR block with a mask between /8 and /32."
   }
 
   validation {

--- a/modules/infra/submodules/network/variables.tf
+++ b/modules/infra/submodules/network/variables.tf
@@ -81,6 +81,14 @@ variable "network" {
 
   validation {
     condition = alltrue([
+      for key, bits in coalesce(var.network.network_bits, {}) :
+      bits > tonumber(regex("[^/]*$", var.network.cidrs.vpc)) if var.network.cidrs.vpc != null
+    ])
+    error_message = "Each network_bits value must be greater than the VPC CIDR's network bits (e.g., > 19 for '10.0.0.0/19')."
+  }
+
+  validation {
+    condition = alltrue([
       for name, cidr in coalesce(var.network.cidrs, {}) :
       can(cidrhost(cidr, 0)) &&
       parseint(split("/", cidr)[1], 10) <= 32 && parseint(split("/", cidr)[1], 10) >= 8


### PR DESCRIPTION
Allows for smaller CIDR ranges avoiding 

```
Plan: 62 to add, 0 to change, 0 to destroy.
╷
│ Error: Invalid value for variable
│
│   on .terraform/modules/infra/modules/infra/main.tf line 67, in module "network":
│   67:   network             = var.network
│     ├────────────────
│     │ var.network.cidrs is object with 2 attributes
│
│ Each of network.cidrs must be a valid CIDR block.
│
│ This was checked by the validation rule at .terraform/modules/infra/modules/infra/submodules/network/variables.tf:80,3-13.
```