### PR TITLE
Fix s3_cidr output based on wrong condition

### DIFF
--- a/modules/infra/main.tf
+++ b/modules/infra/main.tf
@@ -110,7 +110,7 @@ module "bastion" {
 locals {
   cost_usage_report_info = var.domino_cur.provision_cost_usage_report && length(module.cost_usage_report) > 0 ? module.cost_usage_report[0].info : null
   bastion_info           = var.bastion.enabled && length(module.bastion) > 0 ? module.bastion[0].info : null
-  add_s3_pol             = local.create_s3 ? [module.storage.info.s3.iam_policy_arn] : []
+  add_s3_pol             = [module.storage.info.s3.iam_policy_arn]
   add_ecr_pol            = local.create_ecr ? concat([module.storage.info.ecr.iam_policy_arn], local.add_s3_pol) : local.add_s3_pol
   node_iam_policies      = local.cost_usage_report_info != null ? concat(local.add_ecr_pol, [local.cost_usage_report_info.cur_iam_policy_arn]) : local.add_ecr_pol
 }

--- a/modules/infra/submodules/network/outputs.tf
+++ b/modules/infra/submodules/network/outputs.tf
@@ -16,7 +16,7 @@ output "info" {
     eips      = [for k, eip in aws_eip.public : eip.public_ip]
     vpc_cidrs = local.create_vpc ? aws_vpc.this[0].cidr_block : data.aws_vpc.provided[0].cidr_block
     pod_cidrs = local.pod_cidr_blocks
-    s3_cidrs  = local.create_vpc && var.network.create_s3_endpoint ? data.aws_prefix_list.s3[0].cidr_blocks : null
+    s3_cidrs  = local.create_vpc ? data.aws_prefix_list.s3[0].cidr_blocks : null
     ecr_endpoint = local.create_ecr_endpoint ? {
       security_group_id = aws_security_group.ecr_endpoint[0].id
     } : null

--- a/modules/infra/submodules/network/vpc.tf
+++ b/modules/infra/submodules/network/vpc.tf
@@ -49,6 +49,12 @@ resource "aws_vpc_endpoint" "s3" {
   }
 }
 
+
+data "aws_prefix_list" "s3" {
+  count          = local.create_vpc ? 1 : 0
+  prefix_list_id = aws_vpc_endpoint.s3[0].prefix_list_id
+}
+
 resource "aws_security_group" "s3_endpoint" {
   count       = local.create_s3_endpoint ? 1 : 0
   name        = "${var.deploy_id}-s3-endpoint"
@@ -80,11 +86,6 @@ resource "aws_vpc_endpoint" "s3_interface" {
   }
 
   depends_on = [aws_vpc_endpoint.s3]
-}
-
-data "aws_prefix_list" "s3" {
-  count          = local.create_vpc && var.network.create_s3_endpoint ? 1 : 0
-  prefix_list_id = aws_vpc_endpoint.s3[0].prefix_list_id
 }
 
 resource "aws_security_group" "ecr_endpoint" {


### PR DESCRIPTION
- Fixes conditional on the s3 endpoint(gateway) cidr blocks,which we create on most cases.
- Given that we need the monitoring bucket as part of a dataplane deployment we also need the s3 policy.