### PR TITLE
PLAT-9141: terraform/tofu-specific versions of `removed` refs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ parameters:
   terraform_version:
     type: string
     default: "1.10.5"
+  opentofu_version:
+    type: string
+    default: "1.9.0"
   hcledit_version:
     type: string
     default: "0.2.9"
@@ -34,6 +37,20 @@ commands:
     steps:
       - terraform/install:
           terraform_version: << parameters.terraform_version >>
+
+  install_opentofu:
+    description: "Install OpenTofu"
+    parameters:
+      opentofu_version:
+        type: string
+        default: "1.9.0"
+    steps:
+      - run:
+          name: Install OpenTofu
+          working_directory: tests/deploy
+          environment:
+            OPENTOFU_VERSION: << parameters.opentofu_version >>
+          command: bash ci-deploy.sh install_opentofu
 
   install_hcledit:
     description: "Install HCL edit"
@@ -264,14 +281,14 @@ jobs:
     docker:
       - image: cimg/aws:2023.04.1
     parameters:
-      terraform_version:
+      opentofu_version:
         type: string
       helm_version:
         type: string
     steps:
       - checkout
-      - install_tf:
-          terraform_version: << parameters.terraform_version >>
+      - install_opentofu:
+          opentofu_version: << parameters.opentofu_version >>
       - install_helm:
           helm_version: << parameters.helm_version >>
       - setup_tf_mods
@@ -327,7 +344,7 @@ workflows:
     jobs:
       - test-deploy:
           context: aws-oidc
-          terraform_version: << pipeline.parameters.terraform_version >>
+          opentofu_version: << pipeline.parameters.opentofu_version >>
           helm_version: << pipeline.parameters.helm_version >>
 
   test-upgrade-workflow:

--- a/modules/eks/cluster.tf
+++ b/modules/eks/cluster.tf
@@ -94,13 +94,6 @@ locals {
 
 }
 
-removed {
-  from = aws_eks_addon.vpc_cni
-  lifecycle {
-    destroy = false
-  }
-}
-
 resource "null_resource" "kubeconfig" {
   provisioner "local-exec" {
     when    = create

--- a/modules/eks/removed.tf
+++ b/modules/eks/removed.tf
@@ -1,0 +1,6 @@
+removed {
+  from = aws_eks_addon.vpc_cni
+  lifecycle {
+    destroy = false
+  }
+}

--- a/modules/eks/removed.tofu
+++ b/modules/eks/removed.tofu
@@ -1,0 +1,3 @@
+removed {
+  from = aws_eks_addon.vpc_cni
+}

--- a/modules/infra/iam.tf
+++ b/modules/infra/iam.tf
@@ -1,10 +1,3 @@
-removed {
-  from = aws_iam_policy.route53
-  lifecycle {
-    destroy = false
-  }
-}
-
 locals {
   create_eks_role_name = coalesce(var.eks.creation_role_name, "${var.deploy_id}-create-eks")
 }

--- a/modules/infra/removed.tf
+++ b/modules/infra/removed.tf
@@ -1,0 +1,6 @@
+removed {
+  from = aws_iam_policy.route53
+  lifecycle {
+    destroy = false
+  }
+}

--- a/modules/infra/removed.tofu
+++ b/modules/infra/removed.tofu
@@ -1,0 +1,3 @@
+removed {
+  from = aws_iam_policy.route53
+}

--- a/modules/infra/submodules/storage/efs.tf
+++ b/modules/infra/submodules/storage/efs.tf
@@ -73,12 +73,3 @@ moved {
   from = aws_efs_mount_target.eks
   to   = aws_efs_mount_target.eks[0]
 }
-
-
-removed {
-  from = aws_efs_mount_target.eks
-
-  lifecycle {
-    destroy = false
-  }
-}

--- a/modules/infra/submodules/storage/removed.tf
+++ b/modules/infra/submodules/storage/removed.tf
@@ -1,0 +1,7 @@
+removed {
+  from = aws_efs_mount_target.eks
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/modules/infra/submodules/storage/removed.tofu
+++ b/modules/infra/submodules/storage/removed.tofu
@@ -1,0 +1,3 @@
+removed {
+  from = aws_efs_mount_target.eks
+}

--- a/modules/nodes/addons.tf
+++ b/modules/nodes/addons.tf
@@ -1,10 +1,3 @@
-removed {
-  from = aws_eks_addon.this
-  lifecycle {
-    destroy = false
-  }
-}
-
 moved {
   from = aws_eks_addon.this["coredns"]
   to   = aws_eks_addon.post_compute_addons["coredns"]

--- a/modules/nodes/removed.tf
+++ b/modules/nodes/removed.tf
@@ -1,0 +1,6 @@
+removed {
+  from = aws_eks_addon.this
+  lifecycle {
+    destroy = false
+  }
+}

--- a/modules/nodes/removed.tofu
+++ b/modules/nodes/removed.tofu
@@ -1,0 +1,3 @@
+removed {
+  from = aws_eks_addon.this
+}

--- a/modules/single-node/addons.tf
+++ b/modules/single-node/addons.tf
@@ -1,10 +1,3 @@
-removed {
-  from = aws_eks_addon.this
-  lifecycle {
-    destroy = false
-  }
-}
-
 moved {
   from = aws_eks_addon.this["coredns"]
   to   = aws_eks_addon.post_compute_addons["coredns"]

--- a/modules/single-node/removed.tf
+++ b/modules/single-node/removed.tf
@@ -1,0 +1,6 @@
+removed {
+  from = aws_eks_addon.this
+  lifecycle {
+    destroy = false
+  }
+}

--- a/modules/single-node/removed.tofu
+++ b/modules/single-node/removed.tofu
@@ -1,0 +1,3 @@
+removed {
+  from = aws_eks_addon.this
+}

--- a/tests/deploy/ci-deploy.sh
+++ b/tests/deploy/ci-deploy.sh
@@ -81,10 +81,19 @@ install_helm() {
 
 install_hcledit() {
   local hcledit_version="${HCLEDIT_VERSION}"
-  local hcledit_artifact=hcledit_${hcledit_version}_linux_amd64.tar.gz
+  local hcledit_artifact="hcledit_${hcledit_version}_linux_amd64.tar.gz"
   curl -fsSL -o "${hcledit_artifact}" "https://github.com/minamijoyo/hcledit/releases/download/v${hcledit_version}/${hcledit_artifact}"
   tar xvzf "${hcledit_artifact}"
   sudo mv hcledit /usr/local/bin/ && rm "${hcledit_artifact}" && hcledit version
+}
+
+install_opentofu() {
+  local opentofu_version="${OPENTOFU_VERSION}"
+  local opentofu_artifact="tofu_${opentofu_version}_linux_amd64.tar.gz"
+  curl -fsSL -o "${opentofu_artifact}" "https://github.com/opentofu/opentofu/releases/download/v${opentofu_version}/${opentofu_artifact}"
+  tar xvzf "${opentofu_artifact}"
+  sudo mv tofu /usr/local/bin/ && rm "${opentofu_artifact}" && tofu version
+  sudo ln -s /usr/local/bin/tofu /usr/local/bin/terraform && terraform version
 }
 
 set_eks_worker_ami() {


### PR DESCRIPTION
Tofu-pilling us: Compatibility issues are really just around the removed blocks that this adjusts, otherwise we're currently cross-compatible. So this PR makes us both compatible, and sets one of our two deploy tests to use OpenTofu so we can validate cross compatibility in the future to keep our options open.

Background for the removed block: https://opentofu.org/docs/intro/migration/terraform-1.9/#removed-block