### PR TITLE
FSXn filesystem ignore network changes

### DIFF
--- a/modules/infra/submodules/storage/netapp.tf
+++ b/modules/infra/submodules/storage/netapp.tf
@@ -1,5 +1,5 @@
 locals {
-  netapp_subnet_ids = startswith(var.storage.netapp.deployment_type, "MULTI") ? slice(local.private_subnet_ids, 0, 2) : [local.private_subnet_ids[0]]
+  netapp_subnet_ids = startswith(var.storage.netapp.deployment_type, "MULTI") ? sort(slice(local.private_subnet_ids, 0, 2)) : sort([local.private_subnet_ids[0]])
 }
 
 resource "aws_security_group" "netapp" {

--- a/modules/infra/submodules/storage/netapp.tf
+++ b/modules/infra/submodules/storage/netapp.tf
@@ -193,7 +193,7 @@ resource "aws_fsx_ontap_file_system" "eks" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [storage_capacity]
+    ignore_changes        = [storage_capacity, preferred_subnet_id, subnet_ids]
   }
 
   tags = {


### PR DESCRIPTION
[PLAT-9393](https://dominodatalab.atlassian.net/browse/PLAT-9393)

The FSXn Ontap filesystem relies on the list of azs which is not ordered and elements can shuffle triggering a change on `preferred_subnet_id` which causes a [filesystem replacement](https://app.circleci.com/pipelines/gh/cerebrotech/fc-infra-upgrades/3374/workflows/9366ffb2-836a-4d1d-a7cf-deae4fd15180/jobs/7495/parallel-runs/0/steps/0-105?invite=true#step-105-413267_140)