### PR TITLE
Handle long subnet names

### DIFF
--- a/modules/infra/submodules/network/subnets.tf
+++ b/modules/infra/submodules/network/subnets.tf
@@ -21,7 +21,7 @@ locals {
     {
       "az_id" = local.zone_id_by_name[local.az_names[i]]
       "az"    = local.az_names[i]
-      "name"  = "${var.deploy_id}-private-${local.az_names[i]}-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" #TODO: REMOVE THIS
+      "name"  = "${var.deploy_id}-private-${local.az_names[i]}"
     }
   } : {}
 

--- a/modules/infra/submodules/network/subnets.tf
+++ b/modules/infra/submodules/network/subnets.tf
@@ -21,7 +21,7 @@ locals {
     {
       "az_id" = local.zone_id_by_name[local.az_names[i]]
       "az"    = local.az_names[i]
-      "name"  = "${var.deploy_id}-private-${local.az_names[i]}"
+      "name"  = "${var.deploy_id}-private-${local.az_names[i]}-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" #TODO: REMOVE THIS
     }
   } : {}
 

--- a/modules/nodes/main.tf
+++ b/modules/nodes/main.tf
@@ -87,9 +87,9 @@ locals {
   node_groups_by_name = {
     for ng_name, ng in local.node_groups_by_name_pre :
     length(ng_name) <= 63 ? ng_name : (
-      length("${trimsuffix(ng_name, "-${ng.sb_name}")}-${ng.sb_az_id}") <= 63 ?
-      "${trimsuffix(ng_name, "-${ng.sb_name}")}-${ng.sb_az_id}" :
-      substr("${trimsuffix(ng_name, "-${ng.sb_name}")}-${ng.sb_az_id}", 0, 63)
+      length("${ng.ng_name}-${var.eks_info.cluster.specs.name}-${ng.sb_az_id}") <= 63 ?
+      "${ng.ng_name}-${var.eks_info.cluster.specs.name}-${ng.sb_az_id}" :
+      substr("${ng.ng_name}-${var.eks_info.cluster.specs.name}-${ng.sb_az_id}", 0, 63)
     ) => ng
   }
 }


### PR DESCRIPTION
Tested with:

[Infra(subnets) Build](https://app.circleci.com/pipelines/github/dominodatalab/terraform-aws-eks/9892/workflows/77ccda69-258d-4832-b4e6-b40418292ae4/jobs/6898/parallel-runs/0/steps/0-115)

Subnet name is really long
```
  # module.infra.module.network.aws_subnet.private["10.0.64.0/19"] will be created
  + resource "aws_subnet" "private" {
...
      + availability_zone_id                           = "usw2-az1"
 ...
      + tags                                           = {
          + "Name"                                = "circleci-6898-private-*********b-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
          + "kubernetes.io/cluster/circleci-6898" = "shared"
          + "kubernetes.io/role/internal-elb"     = "1"
        }
    }
```


[Nodes Build](https://app.circleci.com/pipelines/github/dominodatalab/terraform-aws-eks/9892/workflows/77ccda69-258d-4832-b4e6-b40418292ae4/jobs/6898/parallel-runs/0/steps/0-117) 

Nodegroup name trims the subnet name and uses the `az-id`
```
module.nodes.aws_eks_node_group.node_groups["compute-usw2-az1"] will be created
```