### PR TITLE
Replace whitespace with _ for eks nodegroup names

### DIFF
--- a/modules/nodes/main.tf
+++ b/modules/nodes/main.tf
@@ -83,7 +83,8 @@ locals {
 
   node_groups_per_zone = concat(local.multi_zone_node_groups, local.single_zone_node_groups)
 
-  node_groups_by_name_pre = { for ngz in local.node_groups_per_zone : strcontains("${ngz.ng_name}-${ngz.sb_name}", var.eks_info.cluster.specs.name) ? "${ngz.ng_name}-${ngz.sb_name}" : "${ngz.ng_name}-${var.eks_info.cluster.specs.name}-${ngz.sb_name}" => ngz }
+  node_groups_by_name_pre = { for ngz in local.node_groups_per_zone : replace(strcontains("${ngz.ng_name}-${ngz.sb_name}", var.eks_info.cluster.specs.name) ? "${ngz.ng_name}-${ngz.sb_name}" : "${ngz.ng_name}-${var.eks_info.cluster.specs.name}-${ngz.sb_name}", " ", "_") => ngz }
+
   node_groups_by_name = {
     for ng_name, ng in local.node_groups_by_name_pre :
     length(ng_name) <= 63 ? ng_name : (

--- a/modules/nodes/main.tf
+++ b/modules/nodes/main.tf
@@ -83,7 +83,7 @@ locals {
 
   node_groups_per_zone = concat(local.multi_zone_node_groups, local.single_zone_node_groups)
 
-  node_groups_by_name_pre = { for ngz in local.node_groups_per_zone : replace(strcontains("${ngz.ng_name}-${ngz.sb_name}", var.eks_info.cluster.specs.name) ? "${ngz.ng_name}-${ngz.sb_name}" : "${ngz.ng_name}-${var.eks_info.cluster.specs.name}-${ngz.sb_name}", " ", "_") => ngz }
+  node_groups_by_name_pre = { for ngz in local.node_groups_per_zone : replace(strcontains("${ngz.ng_name}-${ngz.sb_name}", var.eks_info.cluster.specs.name) ? "${ngz.ng_name}-${ngz.sb_name}" : "${ngz.ng_name}-${var.eks_info.cluster.specs.name}-${ngz.sb_name}", "/[^A-Za-z0-9\\-_.]+/", "_") => ngz }
 
   node_groups_by_name = {
     for ng_name, ng in local.node_groups_by_name_pre :


### PR DESCRIPTION
Workaround for when the subnet name has spaces and causes 

![image](https://github.com/user-attachments/assets/ef272c66-262b-4488-993b-594fb8f2ce3a)

