### PR TITLE
PLAT-9465 Single_nodegroup should not enforce all azs  to contain its instance type

### DIFF
--- a/modules/eks/cluster.tf
+++ b/modules/eks/cluster.tf
@@ -1,3 +1,20 @@
+locals {
+  # See `Subnet requirements for clusters` on https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html
+  eks_unsupported_az_ids = ["use1-az3", "usw1-az2", "cac1-az3"]
+
+  eks_supported_subnets = {
+    for s in var.network_info.subnets.private : s.az_id => s
+    if !contains(local.eks_unsupported_az_ids, s.az_id)
+  }
+
+  eks_number_of_subnets = length(local.eks_supported_subnets) >= 3 ? 3 : 2
+
+  eks_control_plane_subnet_ids = [
+    for az_id in slice(sort(keys(local.eks_supported_subnets)), 0, local.eks_number_of_subnets) :
+    local.eks_supported_subnets[az_id].subnet_id
+  ]
+}
+
 resource "aws_security_group" "eks_cluster" {
   name        = "${local.eks_cluster_name}-cluster"
   description = "EKS cluster security group"
@@ -61,7 +78,7 @@ resource "aws_eks_cluster" "this" {
     endpoint_public_access  = var.eks.public_access.enabled
     public_access_cidrs     = var.eks.public_access.cidrs
     security_group_ids      = [aws_security_group.eks_cluster.id]
-    subnet_ids              = [for s in var.network_info.subnets.private : s.subnet_id]
+    subnet_ids              = local.eks_control_plane_subnet_ids
   }
 
   depends_on = [

--- a/modules/nodes/nodes.tf
+++ b/modules/nodes/nodes.tf
@@ -54,7 +54,7 @@ resource "aws_launch_template" "node_groups" {
 
   lifecycle {
     precondition {
-      condition     = length(setsubtract(each.value.availability_zone_ids, data.aws_ec2_instance_type_offerings.nodes[each.key].locations)) == 0
+      condition     = (lookup(each.value, "single_nodegroup", false) && length(setintersection(each.value.availability_zone_ids, data.aws_ec2_instance_type_offerings.nodes[each.key].locations)) > 0) || length(setsubtract(each.value.availability_zone_ids, data.aws_ec2_instance_type_offerings.nodes[each.key].locations)) == 0
       error_message = <<-EOM
         Instance type(s) ${jsonencode(each.value.instance_types)} for node group ${format("%q", each.key)} are not available in all the given zones:
         given = ${jsonencode(each.value.availability_zone_ids)}


### PR DESCRIPTION
[PLAT-9466](https://dominodatalab.atlassian.net/browse/PLAT-9466)

```
2025-06-20 20:04:17,888 - 
2025-06-20 20:04:17,888 -   on /resources/deployer/deploys/cloud-coatue/terraform/nodes/modules/nodes/modules/nodes/nodes.tf line 57, in resource "aws_launch_template" "node_groups":
2025-06-20 20:04:17,888 -   57:       condition     = length(setsubtract(each.value.availability_zone_ids, data.aws_ec2_instance_type_offerings.nodes[each.key].locations)) == 0
2025-06-20 20:04:17,888 -     ├────────────────
2025-06-20 20:04:17,889 -     │ data.aws_ec2_instance_type_offerings.nodes is object with 4 attributes
2025-06-20 20:04:17,889 -     │ each.key is "karpenter"
2025-06-20 20:04:17,889 -     │ each.value.availability_zone_ids is list of string with 6 elements
2025-06-20 20:04:17,889 - 
2025-06-20 20:04:17,889 - Instance type(s) ["m6a.xlarge"] for node group "karpenter" are not available
2025-06-20 20:04:17,889 - in all the given zones:
2025-06-20 20:04:17,889 - given = ["use1-az1","use1-az2","use1-az3","use1-az4","use1-az5","use1-az6"]
2025-06-20 20:04:17,889 - available = ["use1-az2","use1-az1","use1-az4","use1-az5","use1-az6"]
2025-06-20 20:04:17,908 - Generating plan in json in /resources/deployer/deploys/cloud-coatue/terraform/nodes/terraform.plan.202506202003.json
2025-06-20 20:04:17,909 - ['terraform', 'show', '-json', '/resources/deployer/deploys/cloud-coatue/terraform/nodes/terraform.plan.202506202003']
2025-06-20 20:04:22,004 - <class 'deployer.terraform.exceptions.TerraformException'>
```
Verified [here](https://app.circleci.com/pipelines/gh/cerebrotech/platform-apps/338318/workflows/64a74d33-2e4e-488b-81ce-0b650780535e/jobs/1215059/parallel-runs/0/steps/0-107?invite=true#step-107-3364_23)

Also 
See `Subnet requirements for clusters` on https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html
```
2025-06-26 13:37:29,209 - Error: creating EKS Cluster (mhkatest87878): operation error EKS: CreateCluster, https response error StatusCode: 400, RequestID: adfbadc0-ce64-4171-8193-15faf0928c8c, UnsupportedAvailabilityZoneException: Cannot create cluster 'mhkatest87878' because EKS does not support creating control plane instances in us-east-1e, the targeted availability zone. Retry cluster creation using control plane subnets that span at least two of these availability zones: us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1f. Note, post cluster creation, you can run worker nodes in separate subnets/availability zones from control plane subnets/availability zones passed during cluster creation
```

Verified [here](https://app.circleci.com/pipelines/gh/cerebrotech/platform-apps/338450/workflows/82ee283e-9e1f-4e67-8380-7457a36d32a5/jobs/1215285/parallel-runs/0/steps/0-107?invite=true#step-107-489006_69)

All subnets:
```
"private" = [
  {
    "az" = "us-east-1d"
    "az_id" = "use1-az4"
    "name" = "mhkatest87890-private-us-east-1d"
    "subnet_id" = "subnet-0617536b9a8d5cdd2"
  },
  {
    "az" = "us-east-1e"
    "az_id" = "use1-az3"
    "name" = "mhkatest87890-private-us-east-1e"
    "subnet_id" = "subnet-065e185032ebc867b"
  },
  {
    "az" = "us-east-1f"
    "az_id" = "use1-az5"
    "name" = "mhkatest87890-private-us-east-1f"
    "subnet_id" = "subnet-07357d19cf7580f5f"
  },
  {
    "az" = "us-east-1a"
    "az_id" = "use1-az6"
    "name" = "mhkatest87890-private-us-east-1a"
    "subnet_id" = "subnet-0e9df105dd67c3252"
  },
  {
    "az" = "us-east-1b"
    "az_id" = "use1-az1"
    "name" = "mhkatest87890-private-us-east-1b"
    "subnet_id" = "subnet-01ba81e38f9b2e5d1"
  },
  {
    "az" = "us-east-1c"
    "az_id" = "use1-az2"
    "name" = "mhkatest87890-private-us-east-1c"
    "subnet_id" = "subnet-02ad85d6dd608e41c"
  }
  ```

EKS CP subnets:
```
subnet_ids                = [
  "subnet-01ba81e38f9b2e5d1",
  "subnet-02ad85d6dd608e41c",
  "subnet-0617536b9a8d5cdd2",
]
```


