### PR TITLE
Fix node group name when it gets shortened, trim the region part of t…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 ## NOTE: Changes(rename/add/delete) to pre-commit ids need to be replicated in .github/workflows/terraform-checks.yml(GHA).
-default_stages: [commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -20,7 +19,7 @@ repos:
       - id: check-dependabot
       - id: check-github-actions
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.4
+    rev: v1.99.0
     hooks:
       - id: terraform_validate
         # See #4 on https://github.com/antonbabenko/pre-commit-terraform#terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: check-dependabot
       - id: check-github-actions
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.0
+    rev: v1.99.4
     hooks:
       - id: terraform_validate
         # See #4 on https://github.com/antonbabenko/pre-commit-terraform#terraform_validate

--- a/modules/nodes/main.tf
+++ b/modules/nodes/main.tf
@@ -53,8 +53,8 @@ locals {
   multi_zone_node_groups = [
     for ng_name, ng in local.node_groups : {
       ng_name            = ng_name
-      sb_name            = join("_", [for sb_name, sb in var.network_info.subnets.private : sb.az_id if contains(ng.availability_zone_ids, sb.az_id)])
-      sb_az_id           = join("_", [for sb_name, sb in var.network_info.subnets.private : sb.az_id if contains(ng.availability_zone_ids, sb.az_id)])
+      sb_name            = join("_", [for sb_name, sb in var.network_info.subnets.private : split("-", sb.az_id)[length(split("-", sb.az_id)) - 1] if contains(ng.availability_zone_ids, sb.az_id)])
+      sb_az_id           = join("_", [for sb_name, sb in var.network_info.subnets.private : split("-", sb.az_id)[length(split("-", sb.az_id)) - 1] if contains(ng.availability_zone_ids, sb.az_id)])
       subnet             = { for sb in var.network_info.subnets.private : sb.name => sb if contains(ng.availability_zone_ids, sb.az_id) }
       availability_zones = [for sb in var.network_info.subnets.private : sb.az if contains(ng.availability_zone_ids, sb.az_id)]
       node_group = merge(ng, {
@@ -90,7 +90,7 @@ locals {
     length(ng_name) <= 63 ? ng_name : (
       length("${ng.ng_name}-${var.eks_info.cluster.specs.name}-${ng.sb_az_id}") <= 63 ?
       "${ng.ng_name}-${var.eks_info.cluster.specs.name}-${ng.sb_az_id}" :
-      substr("${ng.ng_name}-${var.eks_info.cluster.specs.name}-${ng.sb_az_id}", 0, 63)
+      replace(substr("${ng.ng_name}-${var.eks_info.cluster.specs.name}-${ng.sb_az_id}", 0, 63), "/[^A-Za-z0-9]+$/", "")
     ) => ng
   }
 }


### PR DESCRIPTION
[PLAT-9476](https://dominodatalab.atlassian.net/browse/PLAT-9476)

The recent node name trim fix caused the nodename to end in `-`

```
2025-07-01 18:36:10,095 - Error: creating EKS Node Group (marcos88269:karpenter-marcos88269-use1-az3_use1-az5_use1-az1_use1-az2_use1-): operation error EKS: CreateNodegroup, https response error StatusCode: 400, RequestID: 12870598-9e12-4606-bf52-7bd85621b1a7, InvalidParameterException: Invalid value: karpenter-marcos88269-use1-az3_use1-az5_use1-az1_use1-az2_use1- : field must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')
```
This change
1. Trims any non-alphanumeric character suffix.
example:
```
replace(substr("karpenter-marcos88269-use1-az1_use1-az2_use1-az4_use1-az3_use1-az5", 0, 63), "/[^A-Za-z0-9]+$/", "")
"karpenter-marcos88269-use1-az1_use1-az2_use1-az4_use1-az3_use1"
```
2. Trims the region part of the az id(`use1`) which is repeated in the concatenated string as it does not add any additional value and produces a cleaner name
example:
```
join("_", [for sb_name in ["use1-az1", "use1-az2", "use1-az4", "use1-az3", "use1-az5"]: split("-", sb_name)[length(split("-", sb_name)) - 1]])
"az1_az2_az4_az3_az5"
```


