### PR TITLE
[DDoS & WAF] Adding hack to avoid using TLS for target groups

### DIFF
--- a/modules/load-balancers/target_group.tf
+++ b/modules/load-balancers/target_group.tf
@@ -4,7 +4,7 @@ resource "aws_lb_target_group" "lb_target_groups" {
   name = "${var.deploy_id}-${substr(each.value.lb_name, 0, 9)}-${each.value.port}"
 
   port        = each.value.port
-  protocol    = each.value.protocol
+  protocol    = contains(["TLS"], each.value.protocol) ? "TCP" : each.value.protocol
   target_type = "instance"
   vpc_id      = var.network_info.vpc_id
 


### PR DESCRIPTION
The idea is to merged this as a temporal solution and be able to deploy lowers envs during this week. and after 24 make the proper changes to support this customization.

Is this code using in other places?
No this code is only used as part of DDoS & WAF (+ Nexus Private Link) so hardcoding this does not affect other pieces