### PR TITLE
Note minimum aws cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Always refer to each section's respective README or documentation for detailed i
 
 ## Prerequisites
 * A host with `ssh-keygen` installed
-* [awscli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+* [awscli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) >= 2.23.6
 * [terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/aws-get-started#install-terraform) >= v1.3.0
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/) cli >= 1.25.0
 * [helm](https://helm.sh/docs/intro/install/) >= 3.9


### PR DESCRIPTION
Add minimum version for aws-cli(`2.23.6`) which would otherwise result in 

```
validation failed:
module.nodes.terraform_data.node_group_update_strategy["gpu-apatil-fannie-private-us-west-2b"] (local-exec): Unknown parameter in updateConfig: "updateStrategy", must be one of: maxUnavailable, maxUnavailablePercentage
module.nodes.terraform_data.node_group_update_strategy["compute-apatil-fannie-private-us-west-2a"] (local-exec): Unknown parameter in updateConfig: "updateStrategy", must be one of: maxUnavailable, maxUnavailablePercentage
```


```
2.23.6
======
* api-change:``eks``: Adds support for UpdateStrategies in EKS Managed Node Groups.
```