### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,5 @@
 
 - [ ] I have noted if a **product** release may land before or after this **infra** change (or vice versa).
     - [ ] I understand that cloud **product** releases and **infrastructure** (Terraform / this repo) changes are separate paths. Product deploys do not go through the same deployer as infra.
+    - [ ] I understand that, depending on my timeline for the infrastructure change, I should flag the update in the appropriate channels in order to trigger a deployer set update for **cloud**.
 - [ ] Where necessary, I have gated product functionality behind CCs/FFs to prevent breaking behavior due to missing infrastructure changes, as per the above risks.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Checklist
+
+- [ ] I have noted if a **product** release may land before or after this **infra** change (or vice versa).
+    - [ ] I understand that cloud **product** releases and **infrastructure** (Terraform / this repo) changes are separate paths. Product deploys do not go through the same deployer as infra.
+- [ ] Where necessary, I have gated product functionality behind CCs/FFs to prevent breaking behavior due to missing infrastructure changes, as per the above risks.


### PR DESCRIPTION
```
## Summary

<!-- What does this PR change and why? -->

## Checklist

- [ ] I have noted if a **product** release may land before 
or after this **infra** change (or vice versa).
    - [ ] I understand that cloud **product** releases and 
    **infrastructure** (Terraform / this repo) changes 
    are separate paths. Product deploys do not go through 
    the same deployer as infra.
    - [ ] I understand that, depending on my timeline for the 
    infrastructure change, I should flag the update 
    in the appropriate channels in order to trigger a deployer 
    set update for **cloud**.
- [ ] Where necessary, I have gated product functionality 
behind CCs/FFs to prevent breaking behavior 
due to missing infrastructure changes, as per the above risks.

```