### PR TITLE
Strip --pod-infra-container-image from AL2 bootstrap.sh on k8s 1.35+

### DIFF
--- a/modules/nodes/templates/linux_user_data_al2.tpl
+++ b/modules/nodes/templates/linux_user_data_al2.tpl
@@ -13,5 +13,8 @@ CONFIG_FILE="/etc/kubernetes/kubelet/kubelet-config.json"
 if [ -f "$CONFIG_FILE" ]; then
   jq '.registryPullQPS=${registry_pull_qps} | .registryBurst=${registry_burst}' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
 fi
+# kubelet 1.35 removed --pod-infra-container-image; strip from legacy AL2 bootstrap.sh.
+# Safe on earlier versions: containerd's sandbox_image (set by the same bootstrap.sh) is the source of truth.
+sed -i 's|--pod-infra-container-image=\$PAUSE_CONTAINER[[:space:]]*||' /etc/eks/bootstrap.sh
 /etc/eks/bootstrap.sh ${cluster_name} ${bootstrap_extra_args} --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL
 ${post_bootstrap_user_data ~}


### PR DESCRIPTION

https://dominodatalab.atlassian.net/browse/PLAT-9915

### What

AL2-flavored EKS Managed Node Groups (custom Ubuntu AMIs) fail to join 1.35 clusters with NodeCreationFailure: Instances failed to join the kubernetes cluster. The legacy /etc/eks/bootstrap.sh (frozen al2 branch of awslabs/amazon-eks-ami, line 534) passes --pod-infra-container-image=$PAUSE_CONTAINER to kubelet. kubelet 1.35 removed that flag (k8s#133779), the service refuses to start with unknown flag, and the node never registers.

### Fix

Strip the flag from /`etc/eks/bootstrap.sh` at userData time, before invoking it:

`sed -i 's|--pod-infra-container-image=$PAUSE_CONTAINER ||' /etc/eks/bootstrap.sh`

Unconditional — the flag has been effectively a no-op since k8s 1.30 (KEP-2371 moved sandbox-image tracking into CRI/containerd). The same bootstrap.sh already configures containerd's sandbox_image, which is now the source of truth for the pause container.