### PR TITLE
AL2023: pre-load pause image into SOCI to avoid containerd 2.2.3 sandbox deadlock

### DIFF
--- a/modules/nodes/templates/linux_user_data_al2023.tpl
+++ b/modules/nodes/templates/linux_user_data_al2023.tpl
@@ -45,7 +45,7 @@ Requires=soci-snapshotter.service
 
 [Service]
 ExecStartPre=/usr/bin/ctr --namespace=k8s.io image import --snapshotter soci --local /etc/eks/pause.tar
-ExecStartPre=/usr/bin/ctr --namespace=k8s.io image label localhost/kubernetes/pause:latest io.cri-containerd.pinned=pinned
+ExecStartPre=-/usr/bin/ctr --namespace=k8s.io image label localhost/kubernetes/pause:latest io.cri-containerd.pinned=pinned
 EOF
 systemctl daemon-reload
 %{ endif ~}

--- a/modules/nodes/templates/linux_user_data_al2023.tpl
+++ b/modules/nodes/templates/linux_user_data_al2023.tpl
@@ -29,6 +29,25 @@ sed -i "s/^max_concurrent_downloads_per_image = .*$/max_concurrent_downloads_per
 max_concurrent_unpacks_per_image="${soci_snapshotter.max_concurrent_unpacks_per_image}"
 sed -i "s/^max_concurrent_unpacks_per_image = .*$/max_concurrent_unpacks_per_image = $max_concurrent_unpacks_per_image/" "$${SOCI_CONFIG_FILE}"
 %{ endif ~}
+
+# TODO: remove once a fixed EKS AL2023 AMI ships.
+# containerd 2.2.3 (AL2023 AMI v20260505+) routes the pinned pause-image unpack
+# through the CRI snapshotter. SOCI has no local pause layers and tries to fetch
+# them from ECR before kubelet's credential provider is up, deadlocking pod
+# sandbox creation and leaving the node NotReady. Pre-import the AMI's bundled
+# pause tarball into SOCI before kubelet starts, and pin it so containerd's GC
+# can't evict it. Tracks https://github.com/awslabs/amazon-eks-ami/issues/2710.
+mkdir -p /etc/systemd/system/kubelet.service.d
+cat > /etc/systemd/system/kubelet.service.d/prestart-load-pause-ctr.conf << 'EOF'
+[Unit]
+After=soci-snapshotter.service
+Requires=soci-snapshotter.service
+
+[Service]
+ExecStartPre=/usr/bin/ctr --namespace=k8s.io image import --snapshotter soci --local /etc/eks/pause.tar
+ExecStartPre=/usr/bin/ctr --namespace=k8s.io image label localhost/kubernetes/pause:latest io.cri-containerd.pinned=pinned
+EOF
+systemctl daemon-reload
 %{ endif ~}
 
 --BOUNDARY


### PR DESCRIPTION
AWS shipped a new EKS-optimized Amazon Linux 2023 AMI (v20260505, released May 6) that upgrades containerd from 2.2.1 to 2.2.3. That upgrade changed how containerd loads the pause container — the tiny image every Kubernetes pod uses as its network/PID anchor.

Old behavior: containerd loaded the pause image directly from its built-in store.

New behavior: containerd routes the pause image through whatever snapshotter is configured. We configure SOCI (an AWS-built snapshotter that pulls container images in parallel for faster startup). SOCI has never seen the pause image in its store, so it tries to fetch the image layers from ECR to fill in metadata. To talk to ECR it needs credentials. To get credentials it needs kubelet's credential helper. For that helper to run, it needs… a pod. Which needs the pause container. Which is the thing we're trying to load.

Kubelet sits there forever reporting NetworkPluginNotReady, the VPC CNI never starts, the node never becomes Ready, and after 30 minutes EKS gives up and reports NodeCreationFailure: Unhealthy nodes.

https://dominodatalab.atlassian.net/browse/PLAT-9929