### PR TITLE
PLAT-9929: revert SOCI pause preload now that upstream AMI v20260512 ships the fix

### DIFF
--- a/modules/nodes/templates/linux_user_data_al2023.tpl
+++ b/modules/nodes/templates/linux_user_data_al2023.tpl
@@ -29,25 +29,6 @@ sed -i "s/^max_concurrent_downloads_per_image = .*$/max_concurrent_downloads_per
 max_concurrent_unpacks_per_image="${soci_snapshotter.max_concurrent_unpacks_per_image}"
 sed -i "s/^max_concurrent_unpacks_per_image = .*$/max_concurrent_unpacks_per_image = $max_concurrent_unpacks_per_image/" "$${SOCI_CONFIG_FILE}"
 %{ endif ~}
-
-# TODO: remove once a fixed EKS AL2023 AMI ships.
-# containerd 2.2.3 (AL2023 AMI v20260505+) routes the pinned pause-image unpack
-# through the CRI snapshotter. SOCI has no local pause layers and tries to fetch
-# them from ECR before kubelet's credential provider is up, deadlocking pod
-# sandbox creation and leaving the node NotReady. Pre-import the AMI's bundled
-# pause tarball into SOCI before kubelet starts, and pin it so containerd's GC
-# can't evict it. Tracks https://github.com/awslabs/amazon-eks-ami/issues/2710.
-mkdir -p /etc/systemd/system/kubelet.service.d
-cat > /etc/systemd/system/kubelet.service.d/prestart-load-pause-ctr.conf << 'EOF'
-[Unit]
-After=soci-snapshotter.service
-Requires=soci-snapshotter.service
-
-[Service]
-ExecStartPre=/usr/bin/ctr --namespace=k8s.io image import --snapshotter soci --local /etc/eks/pause.tar
-ExecStartPre=-/usr/bin/ctr --namespace=k8s.io image label localhost/kubernetes/pause:latest io.cri-containerd.pinned=pinned
-EOF
-systemctl daemon-reload
 %{ endif ~}
 
 --BOUNDARY


### PR DESCRIPTION
Jira: https://dominodatalab.atlassian.net/browse/PLAT-9929

Reverts #441. AWS shipped [`v20260512`](https://github.com/awslabs/amazon-eks-ami/releases/tag/v20260512) which includes the upstream fix ([awslabs/amazon-eks-ami#2717](https://github.com/awslabs/amazon-eks-ami/pull/2717)) for the same containerd 2.2.3 / SOCI sandbox deadlock our user-data hack worked around.

## Hold before merging — rollout is partial

As of 2026-05-14 the fixed AMI is in SSM `recommended` for ~10/13 regions I checked, but **us-east-1, us-west-1, and ap-south-1 are still pointing at the broken `v20260505`**. The GitHub release is also still flagged Pre-release. Merging now reintroduces NodeCreationFailure for fresh deploys in those regions.

Wait until:
- SSM `recommended` for `1.30/1.32/1.33/1.34/1.35 + AL2023` resolves to `v20260512` (or later) in every region we deploy to, and
- the GitHub release flips from Pre-release to Latest.

Spot check command:

```
aws ssm get-parameter --region us-east-1 \
  --name /aws/service/eks/optimized-ami/1.35/amazon-linux-2023/x86_64/standard/recommended/image_name \
  --query 'Parameter.Value' --output text
```

## Test plan
- [ ] Re-run the SSM spot check across us-east-1 / us-west-1 / ap-south-1; all return `v20260512` or later
- [ ] Bring up a fresh AL2023 nodegroup on the post-fix AMI (no user-data hack) and confirm nodes become Ready and aws-node/kube-proxy start cleanly