### PR TITLE
Adding AmazonEC2ContainerRegistryPullOnly to nodes role

### DIFF
--- a/modules/eks/iam.tf
+++ b/modules/eks/iam.tf
@@ -248,6 +248,7 @@ locals {
     "AmazonEKSWorkerNodePolicy",
     "AmazonEKS_CNI_Policy",
     "AmazonEC2ContainerRegistryReadOnly",
+    "AmazonEC2ContainerRegistryPullOnly",
     "AmazonSSMManagedInstanceCore",
     "AmazonElasticFileSystemReadOnlyAccess",
   ]


### PR DESCRIPTION
This PR adds the AmazonEC2ContainerRegistryPullOnly policy to the nodes role to allow the use of ECR Pull-through caches, which specifically require bringing in this particular permission: `ecr:BatchImportUpstreamImage`

The previous policy covering ECR pulls does not include that permission, and in general it is recommended to use the PullOnly variant for this use case but the permissions diff between the two of them is too broad to just swap them out, considering unknown existing use cases that may be relying in these perms. Diff between them:
```diff
$ diff AmazonEC2ContainerRegistryReadOnly AmazonEC2ContainerRegistryPullOnly                                                                 ~/foo 1 ↵
1d0
<                 "ecr:BatchCheckLayerAvailability",
3,5c2
<                 "ecr:DescribeImages",
<                 "ecr:DescribeImageScanFindings"
<                 "ecr:DescribeRepositories",
---
>                 "ecr:BatchImportUpstreamImage"
8,12d4
<                 "ecr:GetLifecyclePolicy",
<                 "ecr:GetLifecyclePolicyPreview",
<                 "ecr:GetRepositoryPolicy",
<                 "ecr:ListImages",
<                 "ecr:ListTagsForResource",
```